### PR TITLE
Add optional publishedAt field to Quiz thrift definition

### DIFF
--- a/src/main/thrift/atoms/quiz.thrift
+++ b/src/main/thrift/atoms/quiz.thrift
@@ -59,7 +59,7 @@ struct QuizAtom {
   // content-atom wrapping?
   1  : required string id
   2  : required string title
-  7  : required bool published
+  7  : required shared.DateTime publishedAt
   6  : required bool revealAtEnd
   8  : required string quizType
   9  : optional i16 defaultColumns

--- a/src/main/thrift/atoms/quiz.thrift
+++ b/src/main/thrift/atoms/quiz.thrift
@@ -59,9 +59,10 @@ struct QuizAtom {
   // content-atom wrapping?
   1  : required string id
   2  : required string title
-  7  : required shared.DateTime publishedAt
+  7  : required bool published
   6  : required bool revealAtEnd
   8  : required string quizType
   9  : optional i16 defaultColumns
   10 : required QuizContent content
+  11  : optional shared.DateTime publishedAt
 }


### PR DESCRIPTION
I've kept the old `published` boolean in there to maintain backwards compatibility as suggested [here](https://diwakergupta.github.io/thrift-missing-guide/#_versioning_compatibility).

The new field is required for tooling to be able to tell if there are unpublished changes to a quiz content-atom.