### PR TITLE
Make root project an aggregation of the other projects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,30 +11,33 @@ organization in ThisBuild := "com.gu"
 
 name := "content-atom-model"
 
-lazy val root = (project in file("."))
+lazy val root = (project in file(".")).aggregate(scala, thriftSrc)
+
+// relative to root
+lazy val thriftSourceDir = file("src/main/thrift")
 
 lazy val scala = project.settings(
   ScroogeSBT.newSettings: _*
 ).settings(
-  ScroogeSBT.scroogeThriftSourceFolder in Compile :=
-    (baseDirectory in root).value / "src/main/thrift",
+  ScroogeSBT.scroogeThriftSourceFolder in Compile := thriftSourceDir,
   name := "content-atom-model-scala",
   libraryDependencies ++= Seq(
     "org.apache.thrift" % "libthrift" % "0.9.2",
     "com.twitter" %% "scrooge-core" % "3.17.0"
-  ),
-  crossScalaVersions := Seq("2.10.4", "2.11.7")
+  )
 )
+
+crossScalaVersions in ThisBuild := Seq("2.10.4", "2.11.7")
 
 // include the thrift source in the jar file so that it can be used as a
 // dependency for applications that wish to use this model to generate thier
 // own thrift rather than directly via the compiled code.
 
-lazy val `thrift-src` = project
+lazy val thriftSrc = (project in file("thrift-src"))
   .settings(
     name := "content-atom-model-thrift-src",
     description := "includable thrift source for the atom model",
-    unmanagedResourceDirectories in Compile += (baseDirectory in root).value / "src/main/thrift",
+    unmanagedResourceDirectories in Compile += thriftSourceDir,
     includeFilter in unmanagedResources := "*.thrift",
     autoScalaLibrary := false,
     crossPaths := false

--- a/build.sbt
+++ b/build.sbt
@@ -67,6 +67,10 @@ thriftSettings ++ inConfig(Thrift) {
   )
 }
 
+releaseCrossBuild := true
+
+releasePublishArtifactsAction := PgpKeys.publishSigned.value
+
 // Publish settings
 
 scmInfo := Some(ScmInfo(url("https://github.com/guardian/content-atom"),
@@ -95,7 +99,7 @@ releaseProcess := Seq[ReleaseStep](
   setReleaseVersion,
   commitReleaseVersion,
   tagRelease,
-  releaseStepTask(PgpKeys.publishSigned),
+  publishArtifacts,
   setNextVersion,
   commitNextVersion,
   releaseStepCommand("sonatypeReleaseAll"),

--- a/doc/new-content-atom.md
+++ b/doc/new-content-atom.md
@@ -36,10 +36,45 @@ make it usable as one of the types that can be placed into
 
 ## Building and publishing your changes
 
-## TODO
+The `root` project aggregates all of the other projects, and we are
+using the [sbt-release](https://github.com/sbt/sbt-release) plugin so
+you should be able to publish everything in one go.
 
-* adding to the `build.sh` file to make sure that your library gets
-    built with the required languages.
+### Preliminary configuration
+
+The first step is to create an account on
+[SonaType](https://oss.sonatype.org) and then
+[log a ticket](https://issues.sonatype.org/) to get added to the
+Guardian profile.
+
+Once that is done, create a file `~/.sbt/<version>/sonatype.sbt` with
+your credentials in, like this:
+
+```
+credentials += Credentials("Sonatype Nexus Repository Manager",
+                           "oss.sonatype.org",
+                           "USERNAME",
+                           "PASSWORD")
+```
+
+You will also need to create a PGP key that you can sign the release
+with. Add the secret key to `~/.sbt/gpg/secring.asc` and upload the
+public key to a key-server. There's more details in the `sbt-pgp`
+plugin [documentation](http://www.scala-sbt.org/sbt-pgp/) and on
+SonaType's page about
+[using PGP signatures](http://central.sonatype.org/pages/working-with-pgp-signatures.html).
+
+### Performing the release
+
+After all that is in place, you should then be able to just type `sbt
+release` from the commmand line (or just `release` from sbt within the
+root project).
+
+This will prompt you to bump the version number and it will tag the
+repo etc. Checkout the `sbt-release` plugin docs linked above for more
+details.
+
+## TODO
 
 * packaging it up and testing it.
 


### PR DESCRIPTION
This means that you can now publish all of the deliverables from the different projects by doing a `+publishSigned` (or a `+release` etc) from the root project, instead of publishing each individual project individually.