### PR TITLE
Follow standard way of packaging

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,8 @@ lazy val scala = project.settings(
   ScroogeSBT.newSettings: _*
 ).settings(
   ScroogeSBT.scroogeThriftSourceFolder in Compile := thriftSourceDir,
-  name := "content-atom-model-scala",
+  includeFilter in unmanagedResources := "*.thrift",
+  name := "content-atom-model",
   libraryDependencies ++= Seq(
     "org.apache.thrift" % "libthrift" % "0.9.2",
     "com.twitter" %% "scrooge-core" % "3.17.0"


### PR DESCRIPTION
Does not prefix artefact with scala and include the thrift file in the jar.