### PR TITLE
Atom: add optional fields for metadata and flags

### DIFF
--- a/src/main/thrift/contentatom.thrift
+++ b/src/main/thrift/contentatom.thrift
@@ -33,6 +33,10 @@ struct ContentChangeDetails {
     4: required i64 revision
 }
 
+struct Flags {
+  1: optional suppressFurniture Boolean
+}
+
 struct Atom {
   1: required ContentAtomID id
   2: required AtomType atomType
@@ -40,8 +44,7 @@ struct Atom {
   4: required string defaultHtml
   5: required AtomData data       // the atom payload
   6: required ContentChangeDetails contentChangeDetails
-  7: optional map<string, string> metadata
-  8: optional map<string, bool> flags
+  7: optional Flags flags
  }
 
 enum EventType { UPDATE, TAKEDOWN }

--- a/src/main/thrift/contentatom.thrift
+++ b/src/main/thrift/contentatom.thrift
@@ -34,7 +34,7 @@ struct ContentChangeDetails {
 }
 
 struct Flags {
-  1: optional suppressFurniture Boolean
+  1: optional bool suppressFurniture
 }
 
 struct Atom {

--- a/src/main/thrift/contentatom.thrift
+++ b/src/main/thrift/contentatom.thrift
@@ -40,6 +40,8 @@ struct Atom {
   4: required string defaultHtml
   5: required AtomData data       // the atom payload
   6: required ContentChangeDetails contentChangeDetails
+  7: optional map<string, string> metadata
+  8: optional map<string, bool> flags
  }
 
 enum EventType { UPDATE, TAKEDOWN }


### PR DESCRIPTION
We need to add some additional information to rendering platforms so I am proposing we add two new sets of metadata.