### PR TITLE
Update video.thrift

### DIFF
--- a/thrift/src/main/thrift/atoms/video.thrift
+++ b/thrift/src/main/thrift/atoms/video.thrift
@@ -7,7 +7,9 @@ typedef i64 Version
 enum AssetType {
   YOUTUBE,
   FACEBOOK,
-  /* not sure about this one ... ? */
+  PODCAST,
+  DAILYMOTION,
+  MAINSTREAM,
   SUBTITLES
 }
 
@@ -20,5 +22,6 @@ struct Asset {
 struct VideoAtom {
   /* the unique ID will be stored in the `atom` data, and this should correspond to the pluto ID */
   2: required list<Asset> assets
-  3: required Version latestVersion
+  3: required Version activeVersion
+  4: required string pluto_project_id
 }


### PR DESCRIPTION
- [ ] As

 we discussed! Adding in some types and adding a pluto_project_id file.

Couple of thoughts - do we want to have some kind of domain-specific metadata for each type, e.g. audio channels, bitrates etc.
How easy will it be to put more AssetTypes in, in the future?
Will we want to create atoms for e.g. youtube or facebook specific content (not intended for g.co.uk)
Would it be a good idea to have things like embed counts here or is that better kept somewhere else?
 