### PR TITLE
Media atom model

### DIFF
--- a/thrift/src/main/thrift/atoms/media.thrift
+++ b/thrift/src/main/thrift/atoms/media.thrift
@@ -1,0 +1,32 @@
+namespace * contentatom.media
+namespace java com.gu.contentatom.thrift.atom.media
+#@namespace scala com.gu.contentatom.thrift.atom.media
+
+typedef i64 Version
+
+enum Platform {
+  YOUTUBE,
+  FACEBOOK,
+  DAILYMOTION,
+  MAINSTREAM,
+  URL
+}
+
+enum AssetType {
+  AUDIO,
+  VIDEO
+}
+
+struct Asset {
+  1: required AssetType assetType
+  2: required Version version
+  3: required string id
+  4: required Platform platform
+}
+
+struct MediaAtom {
+  /* the unique ID will be stored in the `atom` data, and this should correspond to the pluto ID */
+  2: required list<Asset> assets
+  3: required Version activeVersion
+  4: optional string plutoProjectId
+}

--- a/thrift/src/main/thrift/contentatom.thrift
+++ b/thrift/src/main/thrift/contentatom.thrift
@@ -3,15 +3,17 @@ namespace java com.gu.contentatom.thrift
 
 include "atoms/quiz.thrift"
 include "atoms/viewpoints.thrift"
+include "atoms/media.thrift"
 include "shared.thrift"
 
 typedef string ContentAtomID
 
-enum AtomType { QUIZ, VIEWPOINTS }
+enum AtomType { QUIZ, VIEWPOINTS, MEDIA }
 
 union AtomData {
   1: quiz.QuizAtom quiz
   2: viewpoints.ViewpointsAtom viewpoints
+  3: media.MediaAtom media
 }
 
 struct ContentChangeDetails {


### PR DESCRIPTION
We have named this a media atom, to allow for support for audio in the future, but for now it is focussing on video.

It is essentially just a container for pointers to off-platform assets.

The ID, at least in the beginning, will likely map 1-to-1 to a PlutoID but that would be business logic that is enforced outside of the atom model (i.e. at the source of the atom events).

The assets are versioned to allow for the situation where the content has been updated but the latest version of the video has not yet been sent to all of the available platforms.