### PR TITLE
flesh out media atom to be usable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 npm-debug.log
 generated
 target/
+.idea/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "guardian-contentatom",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Content Atom JavaScript, automatically generated from the Thrift definition.",
   "repository": "https://github.com/guardian/content-atom",
   "main": "js/main.js",

--- a/thrift/src/main/thrift/atoms/media.thrift
+++ b/thrift/src/main/thrift/atoms/media.thrift
@@ -17,6 +17,13 @@ enum AssetType {
   VIDEO
 }
 
+enum Category {
+    EXPLAINER,
+    NEWS,
+    FEATURE,
+    DOCUMENTARY
+}
+
 struct Asset {
   1: required AssetType assetType
   2: required Version version
@@ -28,5 +35,9 @@ struct MediaAtom {
   /* the unique ID will be stored in the `atom` data, and this should correspond to the pluto ID */
   2: required list<Asset> assets
   3: required Version activeVersion
-  4: optional string plutoProjectId
+  4: required string title
+  5: required Category category
+  6: optional string plutoProjectId
+  7: optional double duration // milliseconds
+  8: optional string source
 }

--- a/thrift/src/main/thrift/atoms/media.thrift
+++ b/thrift/src/main/thrift/atoms/media.thrift
@@ -18,8 +18,8 @@ enum AssetType {
 }
 
 enum Category {
-    EXPLAINER,
     NEWS,
+    EXPLAINER,
     FEATURE,
     DOCUMENTARY
 }

--- a/thrift/src/main/thrift/atoms/media.thrift
+++ b/thrift/src/main/thrift/atoms/media.thrift
@@ -18,10 +18,10 @@ enum AssetType {
 }
 
 enum Category {
-    NEWS,
+    DOCUMENTARY,
     EXPLAINER,
     FEATURE,
-    DOCUMENTARY
+    NEWS
 }
 
 struct Asset {


### PR DESCRIPTION
We've added:
* title - To make sure the video is at least searchable
* category: There was an editorial decision to make these types of videos, so if we are going to add one, it would have to be well thought out
* duration and source: these will be required for publishing, but as we might not have an asset, duration is optional, and source doesn't need to know at first

This will get us a lot closer to getting one of these into prod.



