### PR TITLE
make activeVersion optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "guardian-contentatom",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Content Atom JavaScript, automatically generated from the Thrift definition.",
   "repository": "https://github.com/guardian/content-atom",
   "main": "js/main.js",

--- a/thrift/src/main/thrift/atoms/media.thrift
+++ b/thrift/src/main/thrift/atoms/media.thrift
@@ -34,7 +34,7 @@ struct Asset {
 struct MediaAtom {
   /* the unique ID will be stored in the `atom` data, and this should correspond to the pluto ID */
   2: required list<Asset> assets
-  3: required Version activeVersion
+  3: optional Version activeVersion
   4: required string title
   5: required Category category
   6: optional string plutoProjectId

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.1.0"
+version in ThisBuild := "2.1.1"


### PR DESCRIPTION
If we don't have assets, we won't be able to have an activeVersion.
It was either this or to use `0` or `null` which always feels rubbish.

@akash1810 @paulmr 