### PR TITLE
Give media-atom assets an optional mime-type

### DIFF
--- a/thrift/src/main/thrift/atoms/media.thrift
+++ b/thrift/src/main/thrift/atoms/media.thrift
@@ -21,7 +21,8 @@ enum Category {
     DOCUMENTARY,
     EXPLAINER,
     FEATURE,
-    NEWS
+    NEWS,
+    HOSTED // commercial content supplied by advertiser
 }
 
 struct Asset {

--- a/thrift/src/main/thrift/atoms/media.thrift
+++ b/thrift/src/main/thrift/atoms/media.thrift
@@ -29,6 +29,7 @@ struct Asset {
   2: required Version version
   3: required string id
   4: required Platform platform
+  5: optional string mimeType
 }
 
 struct MediaAtom {


### PR DESCRIPTION
So we can get all the URL assets for a particular version of a media atom and render them together in an html `video` block, for example.

/cc @paulmr 