### PR TITLE
Add optional poster URL to media atom

### DIFF
--- a/thrift/src/main/thrift/atoms/media.thrift
+++ b/thrift/src/main/thrift/atoms/media.thrift
@@ -42,4 +42,5 @@ struct MediaAtom {
   6: optional string plutoProjectId
   7: optional i64 duration // milliseconds
   8: optional string source
+  9: optional string posterUrl
 }


### PR DESCRIPTION
I think this is the last property we need for hosted videos.

/cc @guardian/labs-beta 