### PR TITLE
ExplainerAtom definition update

### DIFF
--- a/thrift/src/main/thrift/atoms/explainer.thrift
+++ b/thrift/src/main/thrift/atoms/explainer.thrift
@@ -14,5 +14,5 @@ struct ExplainerAtom {
   2: required string title
   3: required string body
   4: required DisplayType displayType
-  5: optional shared.Taxonomy taxonomy
+  5: optional list<string> tags
 }


### PR DESCRIPTION
Moving away from storying tags against an explainer (bad practice),
we will be storing tagsIds (essentially tagsPaths).