### PR TITLE
Content Atom - ensure js/main.js is up to date.

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,8 @@
 exports.contentAtomTypes = require('../generated/gen-nodejs/contentatom_types');
+exports.ctaTypes  = require('../generated/gen-nodejs/cta_types');
+exports.explainerTypes  = require('../generated/gen-nodejs/explainer_types');
+exports.interactiveTypes  = require('../generated/gen-nodejs/interactive_types');
 exports.mediaTypes  = require('../generated/gen-nodejs/media_types');
 exports.quizTypes  = require('../generated/gen-nodejs/quiz_types');
+exports.reviewTypes  = require('../generated/gen-nodejs/review_types');
 exports.shared = require('../generated/gen-nodejs/shared_types');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "guardian-contentatom",
-  "version": "2.1.1",
+  "version": "2.4.7",
   "description": "Content Atom JavaScript, automatically generated from the Thrift definition.",
   "repository": "https://github.com/guardian/content-atom",
   "main": "js/main.js",


### PR DESCRIPTION
The js/main.js file is missing quite a lot of the content atoms that should be there while the js library is languishing quite far behind at 2.1.1 compared to the 2.4.7 we're currently on. I've updated the version to 2.4.7 to bring in line rather than bumping from what it was previously on. Please shout if you'd prefer I did not do this.