### PR TITLE
Add poster image for media atoms.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "guardian-contentatom",
-  "version": "2.4.10",
+  "version": "2.4.11",
   "description": "Content Atom JavaScript, automatically generated from the Thrift definition.",
   "repository": "https://github.com/guardian/content-atom",
   "main": "js/main.js",

--- a/thrift/src/main/thrift/atoms/media.thrift
+++ b/thrift/src/main/thrift/atoms/media.thrift
@@ -2,6 +2,8 @@ namespace * contentatom.media
 namespace java com.gu.contentatom.thrift.atom.media
 #@namespace scala com.gu.contentatom.thrift.atom.media
 
+include "../shared.thrift"
+
 typedef i64 Version
 
 enum Platform {
@@ -53,4 +55,5 @@ struct MediaAtom {
   9: optional string posterUrl
   10: optional string description
   11: optional Metadata metadata
+  12: optional shared.GridImage posterImage
 }

--- a/thrift/src/main/thrift/atoms/media.thrift
+++ b/thrift/src/main/thrift/atoms/media.thrift
@@ -55,5 +55,5 @@ struct MediaAtom {
   9: optional string posterUrl
   10: optional string description
   11: optional Metadata metadata
-  12: optional shared.GridImage posterImage
+  12: optional shared.Image posterImage
 }

--- a/thrift/src/main/thrift/shared.thrift
+++ b/thrift/src/main/thrift/shared.thrift
@@ -160,26 +160,26 @@ struct Taxonomy {
   5: optional list<Reference> references
 }
 
-struct GridImageAssetDimensions {
+struct ImageAssetDimensions {
   1: required i32 height
 
   2: required i32 width
 }
 
-struct GridImageAsset {
+struct ImageAsset {
   1: optional string mimeType
 
   2: required string file
 
-  3: optional GridImageAssetDimensions dimensions
+  3: optional ImageAssetDimensions dimensions
 
   4: optional i64 size
 }
 
-struct GridImage {
-  1: required list<GridImageAsset> assets
+struct Image {
+  1: required list<ImageAsset> assets
 
-  2: optional GridImageAsset master
+  2: optional ImageAsset master
 
   3: required string mediaId
 }

--- a/thrift/src/main/thrift/shared.thrift
+++ b/thrift/src/main/thrift/shared.thrift
@@ -160,3 +160,26 @@ struct Taxonomy {
   5: optional list<Reference> references
 }
 
+struct GridImageAssetDimensions {
+  1: required i32 height
+
+  2: required i32 width
+}
+
+struct GridImageAsset {
+  1: optional string mimeType
+
+  2: required string file
+
+  3: optional GridImageAssetDimensions dimensions
+
+  4: optional i64 size
+}
+
+struct GridImage {
+  1: required list<GridImageAsset> assets
+
+  2: optional GridImageAsset master
+
+  3: required string mediaId
+}


### PR DESCRIPTION
Update thrift definition for poster image for media atoms. Provides more information about the image than just a URL. Subset of the image data from grid.