### PR TITLE
Add content flags

### DIFF
--- a/thrift/src/main/thrift/atoms/media.thrift
+++ b/thrift/src/main/thrift/atoms/media.thrift
@@ -41,6 +41,13 @@ struct Metadata {
   5: optional string channelId
 }
 
+struct Settings {
+  1: optional bool sensitive
+  2: optional bool legallySensitive
+  3: optional bool surpressRelatedContent
+  4: optional bool blockAds
+}
+
 struct MediaAtom {
   /* the unique ID will be stored in the `atom` data, and this should correspond to the pluto ID */
   2: required list<Asset> assets
@@ -53,4 +60,5 @@ struct MediaAtom {
   9: optional string posterUrl
   10: optional string description
   11: optional Metadata metadata
+  12: optional Settings settings
 }

--- a/thrift/src/main/thrift/atoms/media.thrift
+++ b/thrift/src/main/thrift/atoms/media.thrift
@@ -41,13 +41,6 @@ struct Metadata {
   5: optional string channelId
 }
 
-struct Settings {
-  1: optional bool sensitive
-  2: optional bool legallySensitive
-  3: optional bool surpressRelatedContent
-  4: optional bool blockAds
-}
-
 struct MediaAtom {
   /* the unique ID will be stored in the `atom` data, and this should correspond to the pluto ID */
   2: required list<Asset> assets
@@ -60,5 +53,4 @@ struct MediaAtom {
   9: optional string posterUrl
   10: optional string description
   11: optional Metadata metadata
-  12: optional Settings settings
 }

--- a/thrift/src/main/thrift/contentatom.thrift
+++ b/thrift/src/main/thrift/contentatom.thrift
@@ -54,10 +54,7 @@ struct ContentChangeDetails {
 
 struct Flags {
   1: optional bool suppressFurniture
-  2: optional bool sensitive
-  3: optional bool legallySensitive
-  4: optional bool suppressRelatedContent
-  5: optional bool blockAds
+  2: optional bool legallySensitive
 }
 
 struct Atom {

--- a/thrift/src/main/thrift/contentatom.thrift
+++ b/thrift/src/main/thrift/contentatom.thrift
@@ -54,6 +54,10 @@ struct ContentChangeDetails {
 
 struct Flags {
   1: optional bool suppressFurniture
+  2: optional bool sensitive
+  3: optional bool legallySensitive
+  4: optional bool suppressRelatedContent
+  5: optional bool blockAds
 }
 
 struct Atom {


### PR DESCRIPTION
Add the same flags for atoms as seen in composer for content:
- ~~Sensitive~~
- Legally Sensitive
- ~~Suppress related content~~
- ~~blockAds~~

There will need to be a discussion around how flags at an atom level interact with the same flags at a content level and which flag 'wins'

EDIT: Follow up discussion - only legally sensitive will be included