### PR TITLE
Deprecate suppressFurntiture field froms Flags.

### DIFF
--- a/thrift/src/main/thrift/contentatom.thrift
+++ b/thrift/src/main/thrift/contentatom.thrift
@@ -53,7 +53,7 @@ struct ContentChangeDetails {
 }
 
 struct Flags {
-  1: optional bool suppressFurniture
+//1: optional bool suppressFurniture DEPRECATED
   2: optional bool legallySensitive
 }
 


### PR DESCRIPTION
The suppressFurniture field was added to the model as part of an intended feature but it never got implemented. I've double checked and we have no atoms in Elasticsearch with this field. This also breaks our concept of having fields on our data which make little sense and relate to a UI.

I've confirmed all of this with @clloyd on his side.