### PR TITLE
Introduce content-entity library to content-atoms

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,10 @@
 import com.github.bigtoast.sbtthrift.ThriftPlugin._
-import com.twitter.scrooge.ScroogeSBT
 
 import sbtrelease._
 
 import ReleaseStateTransformations._
+
+import com.twitter.scrooge.ScroogeSBT
 
 Sonatype.sonatypeSettings
 
@@ -20,6 +21,21 @@ val commonSettings = Seq(
       <id>paulmr</id>
       <name>Paul Roberts</name>
       <url>https://github.com/paulmr</url>
+    </developer>
+    <developer>
+      <id>LATaylor-guardian</id>
+      <name>Luke Taylor</name>
+      <url>https://github.com/LATaylor-guardian</url>
+    </developer>
+    <developer>
+      <id>mchv</id>
+      <name>Mariot Chauvin</name>
+      <url>https://github.com/mchv</url>
+    </developer>
+    <developer>
+      <id>tomrf1</id>
+      <name>Tom Forbes</name>
+      <url>https://github.com/tomrf1</url>
     </developer>
   </developers>
   ),
@@ -42,39 +58,47 @@ val commonSettings = Seq(
   )
 )
 
-lazy val root = (project in file("."))
+lazy val root = Project(id = "root", base = file("."))
   .aggregate(thrift, scala)
   .settings(commonSettings)
   .settings(
     publishArtifact := false
   )
 
-lazy val scala = (project in file("scala"))
-  .settings(ScroogeSBT.newSettings: _*)
+lazy val thrift = Project(id = "content-atom-model-thrift", base = file("thrift"))
   .settings(commonSettings)
+  .disablePlugins(ScroogeSBT)
   .settings(
-    name := "content-atom-model",
-    description := "Scala library built from Content-atom thrift definition",
-
-    scroogeThriftSourceFolder in Compile := baseDirectory.value / "../thrift/src/main/thrift",
-    includeFilter in unmanagedResources := "*.thrift",
-    unmanagedResourceDirectories in Compile += baseDirectory.value / "../thrift/src/main/thrift",
-    managedSourceDirectories in Compile += (scroogeThriftOutputFolder in Compile).value,
-    libraryDependencies ++= Seq(
-      "org.apache.thrift" % "libthrift" % "0.9.2",
-      "com.twitter" %% "scrooge-core" % "3.17.0"
-    )
-  )
-
-lazy val thrift = (project in file("thrift"))
-  .settings(commonSettings)
-  .settings(
-    name := "content-atom-model-thrift",
+    resolvers += Resolver.sonatypeRepo("releases"),
     description := "Content atom model Thrift files",
     crossPaths := false,
     publishArtifact in packageDoc := false,
     publishArtifact in packageSrc := false,
-    unmanagedResourceDirectories in Compile += { baseDirectory.value / "src/main/thrift" }
+    includeFilter in unmanagedResources := "*.thrift",
+    unmanagedResourceDirectories in Compile += { baseDirectory.value / "src/main/thrift" },
+    libraryDependencies ++= Seq(
+    "com.gu" % "content-entity-thrift" % "0.1.0"
+    )
+  )
+
+lazy val scala = Project(id = "content-atom-model", base = file("scala"))
+  .settings(commonSettings)
+  .dependsOn(thrift)
+  .settings(
+    description := "Scala library built from Content-atom thrift definition",
+    scroogeThriftSourceFolder in Compile := baseDirectory.value / "../thrift/src/main/thrift",
+    includeFilter in unmanagedResources := "*.thrift",
+    scroogeThriftDependencies in Compile ++= Seq(
+      "content-entity-thrift"
+    ),
+    // See: https://github.com/twitter/scrooge/issues/199
+    scroogeThriftSources in Compile ++= {
+      (scroogeUnpackDeps in Compile).value.flatMap { dir => (dir ** "*.thrift").get }
+    },
+    libraryDependencies ++= Seq(
+      "org.apache.thrift" % "libthrift" % "0.9.2",
+      "com.twitter" %% "scrooge-core" % "4.5.0"
+    )
   )
 
 // settings for the thrift plugin, both default and custom

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-import com.github.bigtoast.sbtthrift.ThriftPlugin._
+import com.github.bigtoast.sbtthrift.ThriftPlugin.{thrift => thriftExecutable, _}
 
 import sbtrelease._
 
@@ -146,7 +146,10 @@ thriftSettings ++ inConfig(Thrift) {
     thriftJavaEnabled := false,
     thriftJsOptions := Seq("node"),
     thriftOutputDir <<= baseDirectory / "generated",
-    thriftJsOutputDir <<= thriftOutputDir
+    thriftJsOutputDir <<= thriftOutputDir,
+    thriftExecutable += {
+      " -I " + extractJarsTarget.value.toString
+    }
   )
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -7,4 +7,3 @@ exports.quizTypes  = require('../generated/gen-nodejs/quiz_types');
 exports.reviewTypes  = require('../generated/gen-nodejs/review_types');
 exports.recipeTypes  = require('../generated/gen-nodejs/recipe_types');
 exports.shared = require('../generated/gen-nodejs/shared_types');
-exports.gameTypes  = require('../generated/gen-nodejs/game_types');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "guardian-contentatom",
-  "version": "2.4.17",
+  "version": "2.4.18",
   "description": "Content Atom JavaScript, automatically generated from the Thrift definition.",
   "repository": "https://github.com/guardian/content-atom",
   "main": "js/main.js",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,4 +8,4 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 
-addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "3.16.3")
+addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "4.5.0")

--- a/thrift/src/main/thrift/atoms/review.thrift
+++ b/thrift/src/main/thrift/atoms/review.thrift
@@ -1,3 +1,6 @@
+include "entities/game.thrift"
+include "entities/restaurant.thrift"
+
 namespace * contentatom.review
 namespace java com.gu.contentatom.thrift.atom.review
 #@namespace scala com.gu.contentatom.thrift.atom.review
@@ -13,53 +16,12 @@ struct Rating {
   3: required i16 minRating
 }
 
-struct Geolocation {
-  1: required double lat
-  2: required double lon
-}
-
-struct Address {
-  1: optional string formattedAddress
-  2: optional i16 streetNumber
-  3: optional string streetName
-  4: optional string neighbourhood
-  5: optional string postTown
-  6: optional string locality
-  7: optional string country
-  8: optional string administrativeAreaLevelOne
-  9: optional string administrativeAreaLevelTwo
-  10: optional string postCode
-}
-
-struct Price {
-  //ISO 4217 currency code
-  1: required string currency
-  //Value in the minor unit, e.g. pence/cents
-  2: required i32 value
-}
-
-struct RestaurantReview {
-  1: required string restaurantName
-  2: optional string approximateLocation
-  3: optional string webAddress
-  4: optional Address address
-  5: optional Geolocation geolocation
-}
-
-struct GameReview {
-  1: required string title
-  2: optional string publisher
-  3: required list<string> platforms
-  4: optional Price price
-  5: optional i32 pegiRating
-  6: optional string genre
-}
-
 struct ReviewAtom {
   1: required ReviewType reviewType
   2: required string reviewer
   3: required Rating rating
-  4: optional string reviewSnippet
-  5: optional RestaurantReview restaurantReview
-  6: optional GameReview gameReview
+  4: required string reviewSnippet
+  5: required string entityId
+  6: optional restaurant.Restaurant restaurant
+  7: optional game.Game game
 }


### PR DESCRIPTION
This provides a separation of the review atom and the actual thing being reviewed. The thing being reviewed is now modelled and exists within the content-entity library. Some SBT hackery was required when doing the thrift-js gen. @paulmr thanks for your help.

This PR also updates `scrooge-core` from `3.17.0` to `4.5.0`.