### PR TITLE
Bump content-entity to 0.1.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -87,7 +87,7 @@ val commonSettings = Seq(
     pushChanges
   ),
   libraryDependencies ++= Seq(
-    "com.gu" % "content-entity-thrift" % "0.1.2"
+    "com.gu" % "content-entity-thrift" % "0.1.3"
   )
 )
 


### PR DESCRIPTION
Makes `genre` field a list - https://github.com/guardian/content-entity/pull/4