### PR TITLE
Recipe add ingredients and image  assets

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ lazy val extractJarSettings = Defaults.coreDefaultSettings ++ Seq(
 
 val commonSettings = Seq(
   organization := "com.gu",
-  scalaVersion := "2.12.0",
+  scalaVersion := "2.12.1",
 	crossScalaVersions := Seq("2.11.8", scalaVersion.value),
   scmInfo := Some(ScmInfo(url("https://github.com/guardian/content-atom"),
                           "scm:git:git@github.com:guardian/content-atom.git")),

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.12
+sbt.version=0.13.13

--- a/thrift/src/main/thrift/atoms/recipe.thrift
+++ b/thrift/src/main/thrift/atoms/recipe.thrift
@@ -2,11 +2,13 @@ namespace * contentatom.recipe
 namespace java com.gu.contentatom.thrift.atom.recipe
 #@namespace scala com.gu.contentatom.thrift.atom.recipe
 
+include "../shared.thrift"
+
 struct Tags {
- 1: required list<string> cuisine
- 2: required list<string> category
- 3: required list<string> celebration
- 4: required list<string> dietary
+  1: required list<string> cuisine
+  2: required list<string> category
+  3: required list<string> celebration
+  4: required list<string> dietary
 }
 
 struct Time {
@@ -21,20 +23,26 @@ struct Serves {
   4: optional string unit
 }
 
+struct Range {
+  1: required i16 from
+  2: required i16 to
+}
+
 struct Ingredient {
-    1: required string item
-    2: optional string comment
-    3: required double quantity
-    4: optional string unit
+  1: required string item
+  2: optional string comment
+  3: optional double quantity
+  4: optional Range quantityRange
+  5: optional string unit
 }
 
 struct IngredientsList {
-    1: optional string title
-    2: required list<Ingredient> ingredients
+  1: optional string title
+  2: required list<Ingredient> ingredients
 }
 
 struct RecipeAtom {
-  /* the unique ID will be stored in the `atom` data*/
+  /* the unique ID will be stored in the `atom` data */
   1: required string title
   2: required Tags tags 
   3: required Time time
@@ -42,4 +50,5 @@ struct RecipeAtom {
   5: required list<IngredientsList> ingredientsLists
   6: required list<string> steps
   7: required list<string> credits
+  8: required list<shared.Image> images
 }


### PR DESCRIPTION
- Add ingredients and image assets 
   - [`quantity` is now optional](https://github.com/guardian/content-api/pull/1791) and new `optional` `quantityRange` field has been added.
   - `images` is a required list 

Please some fields have been reordered because no recipes have yet been published

Apart from that I have done some health upgrade:
- `sbt` to `0.13.13`
- scala to `2.12.1`
- fix warnings from `sbt` `0.12` [upgrade](http://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html)
