### PR TITLE
Content Atom - Adding 'story questions' atom.

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -7,4 +7,4 @@ exports.quizTypes  = require('../generated/gen-nodejs/quiz_types');
 exports.reviewTypes  = require('../generated/gen-nodejs/review_types');
 exports.recipeTypes  = require('../generated/gen-nodejs/recipe_types');
 exports.shared = require('../generated/gen-nodejs/shared_types');
-exports.filmTypes = require('../generated/gen-nodejs/film_types');
+exports.storyQuestions = require('../generated/gen-nodejs/storyquestions_types');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "guardian-contentatom",
-  "version": "2.4.31",
+  "version": "2.4.32",
   "description": "Content Atom JavaScript, automatically generated from the Thrift definition.",
   "repository": "https://github.com/guardian/content-atom",
   "main": "js/main.js",

--- a/thrift/src/main/thrift/atoms/storyquestions.thrift
+++ b/thrift/src/main/thrift/atoms/storyquestions.thrift
@@ -2,6 +2,10 @@ namespace * contentatom.storyquestions
 namespace java com.gu.contentatom.thrift.atom.storyquestions
 #@namespace scala com.gu.contentatom.thrift.atom.storyquestions
 
+/* 
+ * Determines what the questions are linked to. This is fundamentally to work around the fact
+ * that we do not have the concept of a story yet.
+ */
 enum RelatedStoryLinkType {
   TAG = 0,
   STORY = 1,

--- a/thrift/src/main/thrift/atoms/storyquestions.thrift
+++ b/thrift/src/main/thrift/atoms/storyquestions.thrift
@@ -1,0 +1,27 @@
+namespace * contentatom.storyquestions
+namespace java com.gu.contentatom.thrift.atom.storyquestions
+#@namespace scala com.gu.contentatom.thrift.atom.storyquestions
+
+enum RelatedStoryLinkType {
+  TAG = 0,
+  STORY = 1,
+}
+
+struct Question {
+  1: required string questionId
+  2: required string questionText
+}
+
+struct QuestionSet {
+  1: required string questionSetId
+  2: required string questionSetTitle
+  3: required list<Question> questions
+}
+
+struct StoryQuestionsAtom {
+  1: required string relatedStoryId
+  2: required RelatedStoryLinkType relatedStoryLinkType 
+  3: required string title
+  4: optional list<QuestionSet> editorialQuestions
+  5: optional list<QuestionSet> userQuestions
+}

--- a/thrift/src/main/thrift/contentatom.thrift
+++ b/thrift/src/main/thrift/contentatom.thrift
@@ -8,6 +8,7 @@ include "atoms/cta.thrift"
 include "atoms/interactive.thrift"
 include "atoms/review.thrift"
 include "atoms/recipe.thrift"
+include "atoms/storyquestions.thrift"
 include "shared.thrift"
 
 typedef string ContentAtomID
@@ -20,7 +21,8 @@ enum AtomType {
   CTA = 4,
   INTERACTIVE = 5,
   REVIEW = 6,
-  RECIPE = 7
+  RECIPE = 7, 
+  STORYQUESTIONS = 8
 }
 
 union AtomData {
@@ -32,6 +34,7 @@ union AtomData {
   6: interactive.InteractiveAtom interactive
   7: review.ReviewAtom review
   8: recipe.RecipeAtom recipe
+  9: storyquestions.StoryQuestionsAtom questions
 }
 
 struct ContentChangeDetails {


### PR DESCRIPTION
A story question is a question, proposed by editorial or a user for a particular story. These questions will be presented in articles and pertain to the given story and present users with the ability to upvote them. This data will be sent to Ophan and dashboards will be built off of the back of it. These dashboards will aid journalistic intent, by allowing content to be commissioned (in some form) based of the direct feedback of our readers. 

See: https://docs.google.com/document/d/1fnQorQ7P9XHkha48BDwo6_f2nv-bPE-J1dcJO0ZOgF0/edit#