### PR TITLE
Add an optional field to store the ID of an Exact Target subscriber list

### DIFF
--- a/thrift/src/main/thrift/atoms/storyquestions.thrift
+++ b/thrift/src/main/thrift/atoms/storyquestions.thrift
@@ -28,5 +28,5 @@ struct StoryQuestionsAtom {
   3: required string title
   4: optional list<QuestionSet> editorialQuestions
   5: optional list<QuestionSet> userQuestions
-  6: optional string listId
+  6: optional string emailListId
 }

--- a/thrift/src/main/thrift/atoms/storyquestions.thrift
+++ b/thrift/src/main/thrift/atoms/storyquestions.thrift
@@ -2,6 +2,8 @@ namespace * contentatom.storyquestions
 namespace java com.gu.contentatom.thrift.atom.storyquestions
 #@namespace scala com.gu.contentatom.thrift.atom.storyquestions
 
+include "../shared.thrift"
+
 /*
  * Determines what the questions are linked to. This is fundamentally to work around the fact
  * that we do not have the concept of a story yet.
@@ -22,11 +24,12 @@ struct QuestionSet {
   3: required list<Question> questions
 }
 
+
 struct StoryQuestionsAtom {
   1: required string relatedStoryId
   2: required RelatedStoryLinkType relatedStoryLinkType
   3: required string title
   4: optional list<QuestionSet> editorialQuestions
   5: optional list<QuestionSet> userQuestions
-  6: optional string emailListId
+  6: optional list<shared.NotificationProvider> providers
 }

--- a/thrift/src/main/thrift/atoms/storyquestions.thrift
+++ b/thrift/src/main/thrift/atoms/storyquestions.thrift
@@ -31,5 +31,5 @@ struct StoryQuestionsAtom {
   3: required string title
   4: optional list<QuestionSet> editorialQuestions
   5: optional list<QuestionSet> userQuestions
-  6: optional shared.NotificationProviders providers
+  6: optional shared.NotificationProviders notifications
 }

--- a/thrift/src/main/thrift/atoms/storyquestions.thrift
+++ b/thrift/src/main/thrift/atoms/storyquestions.thrift
@@ -2,7 +2,7 @@ namespace * contentatom.storyquestions
 namespace java com.gu.contentatom.thrift.atom.storyquestions
 #@namespace scala com.gu.contentatom.thrift.atom.storyquestions
 
-/* 
+/*
  * Determines what the questions are linked to. This is fundamentally to work around the fact
  * that we do not have the concept of a story yet.
  */
@@ -24,8 +24,9 @@ struct QuestionSet {
 
 struct StoryQuestionsAtom {
   1: required string relatedStoryId
-  2: required RelatedStoryLinkType relatedStoryLinkType 
+  2: required RelatedStoryLinkType relatedStoryLinkType
   3: required string title
   4: optional list<QuestionSet> editorialQuestions
   5: optional list<QuestionSet> userQuestions
+  6: optional string listId
 }

--- a/thrift/src/main/thrift/atoms/storyquestions.thrift
+++ b/thrift/src/main/thrift/atoms/storyquestions.thrift
@@ -31,5 +31,5 @@ struct StoryQuestionsAtom {
   3: required string title
   4: optional list<QuestionSet> editorialQuestions
   5: optional list<QuestionSet> userQuestions
-  6: optional list<shared.NotificationProvider> providers
+  6: optional shared.NotificationProviders providers
 }

--- a/thrift/src/main/thrift/shared.thrift
+++ b/thrift/src/main/thrift/shared.thrift
@@ -183,3 +183,18 @@ struct Image {
 
   3: required string mediaId
 }
+
+/**
+ * An abstraction to represent email subscriber lists
+ */
+struct EmailProvider {
+  1: required string name = "exact-target"
+  2: required string listId
+}
+
+/**
+ * Reference to a third-party service used to send notifications
+ */
+struct NotificationProvider {
+  1: optional EmailProvider email
+}

--- a/thrift/src/main/thrift/shared.thrift
+++ b/thrift/src/main/thrift/shared.thrift
@@ -195,6 +195,6 @@ struct EmailProvider {
 /**
  * Reference to a third-party service used to send notifications
  */
-struct NotificationProvider {
+struct NotificationProviders {
   1: optional EmailProvider email
 }


### PR DESCRIPTION
After discussion, this is going to be a permanent feature so it makes sense to add this field to the storyquestions atom itself.