### PR TITLE
add trail image to media atom

### DIFF
--- a/thrift/src/main/thrift/atoms/media.thrift
+++ b/thrift/src/main/thrift/atoms/media.thrift
@@ -74,4 +74,5 @@ struct MediaAtom {
   15: optional list<string> byline
   16: optional list<string> commissioningDesks
   17: optional list<string> keywords
+  18: optional shared.Image trailImage
 }

--- a/thrift/src/main/thrift/shared.thrift
+++ b/thrift/src/main/thrift/shared.thrift
@@ -164,6 +164,8 @@ struct ImageAssetDimensions {
   1: required i32 height
 
   2: required i32 width
+
+  3: optional string aspectRatio
 }
 
 struct ImageAsset {
@@ -182,4 +184,6 @@ struct Image {
   2: optional ImageAsset master
 
   3: required string mediaId
+
+  4: optional string source
 }


### PR DESCRIPTION
Add new fields to media atom to allow for adding composer trail images in mam. 
Composer trail image is saved in trail image field. The image model needs new fields because composer requires more information from the grid.