### PR TITLE
Storyquestions 'closed' flag

### DIFF
--- a/thrift/src/main/thrift/atoms/storyquestions.thrift
+++ b/thrift/src/main/thrift/atoms/storyquestions.thrift
@@ -32,4 +32,5 @@ struct StoryQuestionsAtom {
   4: optional list<QuestionSet> editorialQuestions
   5: optional list<QuestionSet> userQuestions
   6: optional shared.NotificationProviders notifications
+  7: optional DateTime closeDate
 }


### PR DESCRIPTION
Currently Editorial remove the atom from content when they want to close the questions.
It's preferable to leave the atom on the content, with the ability to hide it later.