### PR TITLE
add new image fields

### DIFF
--- a/thrift/src/main/thrift/atoms/media.thrift
+++ b/thrift/src/main/thrift/atoms/media.thrift
@@ -130,4 +130,7 @@ struct MediaAtom {
 
   /** suppress related content of the (optional) Composer page **/
   21: optional bool suppressRelatedContent
+
+  /** alt text for Composer page trail image**/
+  22: optional string altText
 }

--- a/thrift/src/main/thrift/shared.thrift
+++ b/thrift/src/main/thrift/shared.thrift
@@ -186,6 +186,11 @@ struct Image {
   3: required string mediaId
 
   4: optional string source
+
+  5: optional string suppliersReference
+
+  6: optional string photographer
+
 }
 
 /**

--- a/thrift/src/main/thrift/shared.thrift
+++ b/thrift/src/main/thrift/shared.thrift
@@ -185,12 +185,14 @@ struct Image {
 
   3: required string mediaId
 
+  /** aka `credit` or `provider` in the IPTC metadata spec **/
   4: optional string source
 
-  5: optional string suppliersReference
+  /** fullname of the image photographer **/
+  5: optional string photographer
 
-  6: optional string photographer
-
+  /** description of image, used by screen readers **/
+  6: optional string altText
 }
 
 /**


### PR DESCRIPTION
We also need to save the suppliers reference and the photographer fields with the trail images that are included in composer video pages. These fields do not have to appear in capi. 

