### PR TITLE
Add the ability to multiple answers 

### DIFF
--- a/thrift/src/main/thrift/atoms/storyquestions.thrift
+++ b/thrift/src/main/thrift/atoms/storyquestions.thrift
@@ -13,9 +13,20 @@ enum RelatedStoryLinkType {
   STORY = 1,
 }
 
+enum AnswerType {
+  CONTENT = 0,
+  ATOM = 1
+}
+
+struct Answer {
+  1: required string answerId
+  2: required AnswerType answerType
+}
+
 struct Question {
   1: required string questionId
   2: required string questionText
+  3: optional list<Answer> answers = empty
 }
 
 struct QuestionSet {


### PR DESCRIPTION
We would like to have the ability to track answers of questions in multiple forms (content, atom, etc..). We currently have the ability to do it for a set of questions but this is too general. I have define `answers` as a collection in case someone would like to commission multiple pieces for a given question. I am not expecting to be canonical but having the ability allows us to be `future proof`

This feature will be used for both:

- Tracking in `ophan` commissioned responses to a given question
- Automate sending emails when a response has been commissioned.
 

