### PR TITLE
Add embargo date field for atoms

### DIFF
--- a/thrift/src/main/thrift/contentatom.thrift
+++ b/thrift/src/main/thrift/contentatom.thrift
@@ -71,6 +71,9 @@ struct ContentChangeDetails {
 
   /** scheduled launch date */
   6: optional shared.ChangeRecord scheduledLaunch
+
+  /*** embargo date **/
+  7: optional shared.ChangeRecord embargo
 }
 
 struct Flags {


### PR DESCRIPTION
This adds a field an embargo field to the model.

NB: changes to the ES mapping are required, as this field will need to appear in CAPI