### PR TITLE
Skip to version 2.4.57-SNAPSHOT

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.4.56-SNAPSHOT"
+version in ThisBuild := "2.4.57-SNAPSHOT"


### PR DESCRIPTION
This is required to fix a failed deploy of the previous' version artifact on sonatype