### PR TITLE
Add expiryDate field

### DIFF
--- a/thrift/src/main/thrift/contentatom.thrift
+++ b/thrift/src/main/thrift/contentatom.thrift
@@ -72,8 +72,11 @@ struct ContentChangeDetails {
   /** scheduled launch date */
   6: optional shared.ChangeRecord scheduledLaunch
 
-  /*** embargo date **/
+  /** embargo date */
   7: optional shared.ChangeRecord embargo
+
+  /** expiry date */
+  8: optional shared.ChangeRecord expiryDate
 }
 
 struct Flags {


### PR DESCRIPTION

Adds an expiryDate field at the `ContentChangeDetails` level. This is part of the work to make it possible to filter atoms on CAPI by date range