### PR TITLE
add expiry field, deprecate expiryDate field

### DIFF
--- a/thrift/src/main/thrift/contentatom.thrift
+++ b/thrift/src/main/thrift/contentatom.thrift
@@ -75,8 +75,11 @@ struct ContentChangeDetails {
   /** embargo date */
   7: optional shared.ChangeRecord embargo
 
+//this has been deprecated due to incorrect naming and should not be used
+//8: optional shared.ChangeRecord expiryDate
+
   /** expiry date */
-  8: optional shared.ChangeRecord expiryDate
+  9: optional shared.ChangeRecord expiry
 }
 
 struct Flags {


### PR DESCRIPTION
Adds an expiry field at the ContentChangeDetails level. This is part of the work to make it possible to filter atoms on CAPI by date range. Deprecate wrong expiryDate field
