### PR TITLE
Commons division atom

### DIFF
--- a/thrift/src/main/thrift/atoms/commonsdivision.thrift
+++ b/thrift/src/main/thrift/atoms/commonsdivision.thrift
@@ -1,0 +1,22 @@
+namespace * contentatom.commonsdivision
+namespace java com.gu.contentatom.thrift.atom.commonsdivision
+#@namespace scala com.gu.contentatom.thrift.atom.commonsdivision
+
+include "../shared.thrift"
+
+struct MP {
+  1: required string name
+  2: required string party
+}
+
+struct Votes {
+  1: required list<MP> ayes
+  2: required list<MP> noes
+}
+
+struct CommonsDivision {
+  1: required string parliamentId
+  2: optional string description
+  3: required shared.DateTime date
+  4: required Votes votes
+}

--- a/thrift/src/main/thrift/contentatom.thrift
+++ b/thrift/src/main/thrift/contentatom.thrift
@@ -13,6 +13,7 @@ include "atoms/review.thrift"
 include "atoms/recipe.thrift"
 include "atoms/storyquestions.thrift"
 include "atoms/timeline.thrift"
+include "atoms/commonsdivision.thrift"
 include "shared.thrift"
 
 typedef string ContentAtomID
@@ -30,7 +31,8 @@ enum AtomType {
   QANDA = 9,
   PROFILE = 10,
   GUIDE = 11,
-  TIMELINE = 12
+  TIMELINE = 12,
+  COMMONSDIVISION = 13
 }
 
 union AtomData {
@@ -47,6 +49,7 @@ union AtomData {
   11: guide.GuideAtom guide
   12: profile.ProfileAtom profile
   13: timeline.TimelineAtom timeline
+  14: commonsdivision.CommonsDivision commonsDivision
 }
 
 struct ContentChangeDetails {


### PR DESCRIPTION
I considered using the content-entity library to model the MPs, but decided against it. It would involve creating the entities in capi and linking to them with entityIds. We can add an optional Person entity field later if we decide it's useful to have that relationship.