### PR TITLE
Add 4 new properties on image

### DIFF
--- a/thrift/src/main/thrift/shared.thrift
+++ b/thrift/src/main/thrift/shared.thrift
@@ -178,6 +178,14 @@ struct ImageAsset {
   5: optional string aspectRatio
 
   6: optional string credit
+  
+  7: optional string copyright
+  
+  8: optional string source
+  
+  9: optional string photographer
+  
+  10: optional string suppliersReference
 }
 
 struct Image {


### PR DESCRIPTION
We want to add 4 new fields to images within atoms:

1. source
2. copyright
3. photographer
4. suppliersReference

[Related ElasticSearch Mapping Change](https://github.com/guardian/content-api/pull/2085) 

[Trello ticket](https://trello.com/c/GexFvYIf/240-add-new-fields-for-atom-images-adding-fields-for-atom-images-copyright-source-photograph-so-rcs-can-better-process-rights)
