### PR TITLE
AudioAtom

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,8 +36,8 @@ lazy val extractJarSettings = Defaults.coreDefaultSettings ++ Seq(
 
 val commonSettings = Seq(
   organization := "com.gu",
-  scalaVersion := "2.12.3",
-	crossScalaVersions := Seq("2.11.11", scalaVersion.value),
+  scalaVersion := "2.12.8",
+	crossScalaVersions := Seq("2.11.12", scalaVersion.value),
   scmInfo := Some(ScmInfo(url("https://github.com/guardian/content-atom"),
                           "scm:git:git@github.com:guardian/content-atom.git")),
 

--- a/thrift/src/main/thrift/atoms/audio.thrift
+++ b/thrift/src/main/thrift/atoms/audio.thrift
@@ -16,5 +16,9 @@ struct AudioAtom {
   // MP3 audio track. We don't support other formats
   3: required string trackUrl
 
+  // Length in seconds of the audio track
   4: required i32 duration
+
+  // ID of the article page to link to
+  5: required string contentId
 }

--- a/thrift/src/main/thrift/atoms/audio.thrift
+++ b/thrift/src/main/thrift/atoms/audio.thrift
@@ -1,0 +1,20 @@
+namespace * contentatom.audio
+namespace java com.gu.contentatom.thrift.atom.audio
+#@namespace scala com.gu.contentatom.thrift.atom.audio
+
+include "../shared.thrift"
+
+struct AudioAtom {
+  // Most probably the title of the podcast, but can be a generic
+  // term if necessary
+  1: required string kicker
+
+  // Cover art for the podcast/audio. Can either be the podcast
+  // album art of a picture chosen specifically for this episode.
+  2: required string coverUrl
+
+  // MP3 audio track. We don't support other formats
+  3: required string trackUrl
+
+  4: required i32 duration
+}

--- a/thrift/src/main/thrift/atoms/audio.thrift
+++ b/thrift/src/main/thrift/atoms/audio.thrift
@@ -4,6 +4,14 @@ namespace java com.gu.contentatom.thrift.atom.audio
 
 include "../shared.thrift"
 
+struct OffPlatform {
+  1: optional string applePodcastsUrl
+
+  2: optional string googlePodcastsUrl
+
+  3: optional string spotifyUrl
+}
+
 struct AudioAtom {
   // Most probably the title of the podcast, but can be a generic
   // term if necessary
@@ -21,4 +29,7 @@ struct AudioAtom {
 
   // ID of the article page to link to
   5: required string contentId
+
+  // Off-platform links
+  6: optional OffPlatform offPlatformLinks
 }

--- a/thrift/src/main/thrift/contentatom.thrift
+++ b/thrift/src/main/thrift/contentatom.thrift
@@ -34,7 +34,8 @@ enum AtomType {
   GUIDE = 11,
   TIMELINE = 12,
   COMMONSDIVISION = 13,
-  CHART = 14
+  CHART = 14,
+  AUDIO = 15
 }
 
 union AtomData {
@@ -53,6 +54,7 @@ union AtomData {
   13: timeline.TimelineAtom timeline
   14: commonsdivision.CommonsDivision commonsDivision
   15: chart.ChartAtom chart
+  16: audio.AudioAtom audio
 }
 
 struct ContentChangeDetails {

--- a/thrift/src/main/thrift/contentatom.thrift
+++ b/thrift/src/main/thrift/contentatom.thrift
@@ -15,6 +15,7 @@ include "atoms/storyquestions.thrift"
 include "atoms/timeline.thrift"
 include "atoms/commonsdivision.thrift"
 include "atoms/chart.thrift"
+include "atoms/audio.thrift"
 include "shared.thrift"
 
 typedef string ContentAtomID


### PR DESCRIPTION
Adds a new atom for podcast episodes, which will end up looking like this:

![46074690-37be6780-c180-11e8-87e4-d80439bae630](https://user-images.githubusercontent.com/629976/50168436-56498000-02e3-11e9-8a51-bbbb65097b1f.png)

The authoring tool will let users enter the URL of an episode page so that the back-end can then query CAPI and pre-fill everything with default data.