### PR TITLE
Revert "add new image fields"

### DIFF
--- a/thrift/src/main/thrift/atoms/media.thrift
+++ b/thrift/src/main/thrift/atoms/media.thrift
@@ -131,7 +131,4 @@ struct MediaAtom {
 
   /** suppress related content of the (optional) Composer page **/
   21: optional bool suppressRelatedContent
-
-  /** alt text for Composer page trail image**/
-  22: optional string altText
 }

--- a/thrift/src/main/thrift/shared.thrift
+++ b/thrift/src/main/thrift/shared.thrift
@@ -195,14 +195,7 @@ struct Image {
 
   3: required string mediaId
 
-  /** aka `credit` or `provider` in the IPTC metadata spec **/
   4: optional string source
-
-  /** fullname of the image photographer **/
-  5: optional string photographer
-
-  /** description of image, used by screen readers **/
-  6: optional string altText
 }
 
 /**


### PR DESCRIPTION
Reverts guardian/content-atom#104

These fields did not make it into CAPI since they're not used anywhere, so it's safe to revert. I'll release capi-models as soon as this is out.