### PR TITLE
add livestream as a category for media atoms

### DIFF
--- a/thrift/src/main/thrift/atoms/media.thrift
+++ b/thrift/src/main/thrift/atoms/media.thrift
@@ -25,7 +25,8 @@ enum Category {
   FEATURE = 2,
   NEWS = 3,
   HOSTED = 4, // commercial content supplied by advertiser
-  PAID = 5 // commercial content paid for by third-party
+  PAID = 5, // commercial content paid for by third-party
+  LIVESTREAM = 6
 }
 
 /** how a YouTube video can be watched **/


### PR DESCRIPTION
this is to allow rendering clients to distinguish a live stream from a normal video



<!-- Your thrift defintions need to also include a scala namespace. It looks like a comment but it's important to have it or generated scala isn't packaged correctly. See the README for more details. -->

<!-- Please ensure you have made corresponding changes to the elasticsearch mappings in CAPI https://git.io/v7cQs ? -->
