### PR TITLE
Enforce libthrift 0.9.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -131,9 +131,14 @@ lazy val scala = Project(id = "content-atom-model", base = file("scala"))
       (scroogeUnpackDeps in Compile).value.flatMap { dir => (dir ** "*.thrift").get }
     },
     libraryDependencies ++= Seq(
-      "org.apache.thrift" % "libthrift" % "0.9.3",
+      "org.apache.thrift" % "libthrift" % "0.9.1",
       "com.twitter" %% "scrooge-core" % "4.18.0"
-    )
+    ),
+    
+    /**
+      * WARNING - upgrading the following will break clients
+      */
+    dependencyOverrides += "org.apache.thrift" % "libthrift" % "0.9.1"
   )
 
 // settings for the thrift plugin, both default and custom


### PR DESCRIPTION
This library is pulling in v0.9.3 of libthrift despite downstream libraries overriding it, which seems to have broken client applications like frontend and MAPI when the Thrift model is updated.

I've tested this by updating all downstream dependencies and using in frontend with both the PROD and CODE versions of concierge (the former using an older model, the latter the latest one), to confirm this is working in both cases.

Addendum: to be fair, I noticed the facia client was using an old version of the CAPI model and this may be another source of incompatibility. I will update the docs so that, every time we update the model, we make sure all downstream libraries are updated too.