### PR TITLE
youtube specific title and description

### DIFF
--- a/thrift/src/main/thrift/atoms/media.thrift
+++ b/thrift/src/main/thrift/atoms/media.thrift
@@ -50,6 +50,11 @@ struct PlutoData {
   3: optional string masterId
 }
 
+struct YoutubeData {
+  1: required string title
+  2: optional string description
+}
+
 struct Metadata {
   /**
     * tags to be applied to the YouTube video
@@ -79,6 +84,8 @@ struct Metadata {
 
   /** where the master is in Pluto **/
   8: optional PlutoData pluto
+
+  9: optional YoutubeData youtube
 }
 
 struct MediaAtom {


### PR DESCRIPTION
This is to enable https://github.com/guardian/media-atom-maker/pull/848.

<!-- Your thrift defintions need to also include a scala namespace. It looks like a comment but it's important to have it or generated scala isn't packaged correctly. See the README for more details. -->

<!-- Please ensure you have made corresponding changes to the elasticsearch mappings in CAPI https://git.io/v7cQs ? -->
