### PR TITLE
Add author to atoms

### DIFF
--- a/thrift/src/main/thrift/Profile.thrift
+++ b/thrift/src/main/thrift/Profile.thrift
@@ -1,0 +1,18 @@
+namespace java com.gu.contentatom.thrift
+
+/** Identifies an entity (human or not) who wrote an atom */
+struct Profile {
+  1: required string id
+
+  2: optional string title
+
+  3: required string firstName
+
+  4: required string lastName
+
+  5: optional string emailAddress
+
+  6: optional string twitterHandle
+
+  7: optional string imageUrl
+}

--- a/thrift/src/main/thrift/contentatom.thrift
+++ b/thrift/src/main/thrift/contentatom.thrift
@@ -17,6 +17,7 @@ include "atoms/commonsdivision.thrift"
 include "atoms/chart.thrift"
 include "atoms/audio.thrift"
 include "atoms/shared.thrift"
+include "Profile.thrift"
 
 typedef string ContentAtomID
 

--- a/thrift/src/main/thrift/contentatom.thrift
+++ b/thrift/src/main/thrift/contentatom.thrift
@@ -111,7 +111,7 @@ struct Atom {
   9: optional list<string> commissioningDesks = []
 
   /** tag IDs for the people who authored that atom */
-  10: optional list<Profile.Profile> authors = []
+  10: optional list<Profile.Profile> authors
  }
 
 enum EventType {

--- a/thrift/src/main/thrift/contentatom.thrift
+++ b/thrift/src/main/thrift/contentatom.thrift
@@ -108,6 +108,9 @@ struct Atom {
   7: optional Flags flags
   8: optional string title
   9: optional list<string> commissioningDesks = []
+
+  /** tag IDs for the people who authored that atom */
+  10: optional list<Profile.Profile> authors = []
  }
 
 enum EventType {


### PR DESCRIPTION
Reference:

> **Bylines are good**. Although there isn’t a specific field to put in a byline, we have been bylining some snippets with the author’s name in bold linking through to their profile page, and their job title in italics. This sends a strong signal of reliability to the user, for example that a snippet has been written by a relevant science correspondent, or the political editor etc

We need to instrument that in the tooling so that journalists don't need to supply that information manually, make typing errors and so on and so forth.