### PR TITLE
WIP: Add emailsignup atom

### DIFF
--- a/thrift/src/main/thrift/atoms/emailsignup.thrift
+++ b/thrift/src/main/thrift/atoms/emailsignup.thrift
@@ -1,0 +1,17 @@
+namespace * contentatom.emailsignup
+namespace java com.gu.contentatom.thrift.atom.emailsignup
+#@namespace scala com.gu.contentatom.thrift.atom.emailsignup
+
+include "shared.thrift"
+
+struct EmailSignUpAtom {
+  // email list name
+  1: required string emailListName
+
+  // Text to be displayed to users to describe what they are signing up for
+  // e.g. "Sign up to the daily Business Today email"
+  2: required string text
+
+  // The exact target ID for the email list
+  3: required string emailListId
+}

--- a/thrift/src/main/thrift/atoms/emailsignup.thrift
+++ b/thrift/src/main/thrift/atoms/emailsignup.thrift
@@ -8,10 +8,14 @@ struct EmailSignUpAtom {
   // email list name
   1: required string emailListName
 
-  // Text to be displayed to users to describe what they are signing up for
-  // e.g. "Sign up to the daily Business Today email"
-  2: required string text
+  // Main text to be displayed to user asking for sign up action,
+  // e.g. "Sign up to get emials for this series, Guns and lies in America"
+  2: required string formTitle
+
+  // Additional text describing what will happen on sign up,
+  // e.g. "You'll get an email each time we release a part of our investigation."
+  3: required string formDescription
 
   // The exact target ID for the email list
-  3: required string emailListId
+  4: required string emailListId
 }

--- a/thrift/src/main/thrift/atoms/emailsignup.thrift
+++ b/thrift/src/main/thrift/atoms/emailsignup.thrift
@@ -15,7 +15,4 @@ struct EmailSignUpAtom {
   // Additional text describing what will happen on sign up,
   // e.g. "You'll get an email each time we release a part of our investigation."
   3: optional string formDescription
-
-  // Identifier for the email list
-  4: required string emailListId
 }

--- a/thrift/src/main/thrift/atoms/emailsignup.thrift
+++ b/thrift/src/main/thrift/atoms/emailsignup.thrift
@@ -5,7 +5,7 @@ namespace java com.gu.contentatom.thrift.atom.emailsignup
 include "shared.thrift"
 
 struct EmailSignUpAtom {
-  // email list name
+  // Email list name for selection in atom-workshop
   1: required string emailListName
 
   // Main text to be displayed to user asking for sign up action,
@@ -14,8 +14,8 @@ struct EmailSignUpAtom {
 
   // Additional text describing what will happen on sign up,
   // e.g. "You'll get an email each time we release a part of our investigation."
-  3: required string formDescription
+  3: optional string formDescription
 
-  // The exact target ID for the email list
+  // Identifier for the email list
   4: required string emailListId
 }

--- a/thrift/src/main/thrift/contentatom.thrift
+++ b/thrift/src/main/thrift/contentatom.thrift
@@ -17,6 +17,7 @@ include "atoms/commonsdivision.thrift"
 include "atoms/chart.thrift"
 include "atoms/audio.thrift"
 include "atoms/shared.thrift"
+include "atoms/emailsignup.thrift"
 
 typedef string ContentAtomID
 
@@ -36,7 +37,8 @@ enum AtomType {
   TIMELINE = 12,
   COMMONSDIVISION = 13,
   CHART = 14,
-  AUDIO = 15
+  AUDIO = 15,
+  EMAILSIGNUP = 16
 }
 
 union AtomData {
@@ -56,6 +58,7 @@ union AtomData {
   14: commonsdivision.CommonsDivision commonsDivision
   15: chart.ChartAtom chart
   16: audio.AudioAtom audio
+  17: emailsignup.EmailSignUpAtom emailsignup
 }
 
 struct ContentChangeDetails {


### PR DESCRIPTION
This should support an atom type for Editorial email sign up boxes, currently included as html snippets like this:

```
<figure class="element element-embed" data-alt="Business email signup">
<iframe src="https://www.theguardian.com/email/form/plaintone/3887" height="42px" data-form-title="Sign up for Business Today" data-form-description="Get the headlines and editors' picks every weekday morning." scrolling="no" seamless="" frameborder="0" class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe js-email-sub__iframe--article" data-form-success-desc="Thanks for signing up" data-node-uid="2"></iframe>
<figcaption class="caption caption--img">
Sign up to the daily Business Today email or follow Guardian Business on Twitter at @BusinessDesk
</figcaption>
</figure>
```


This is rendered like below:

![image](https://user-images.githubusercontent.com/9820960/64121654-6208a400-cd97-11e9-9d64-43ea652acf73.png)

An atom type for these will allow editors to create reusable components for different email lists, reducing the chances that an email sign up box will be added signing users up to the wrong email (copying, pasting and editing the html is error prone!). 

As an aside, the new atom should be rendered more like this:

![Picture 59](https://user-images.githubusercontent.com/9820960/64121718-8fede880-cd97-11e9-88dd-6b203302e20a.png)

TODO: 
- [ ] Confirm which fields are actually necessary (this is a guess)
- [ ] [Add field to Elasticsearch mapping in CAPI](https://github.com/guardian/content-api/blob/master/docs/adding-a-new-field-to-capi.md/#elasticsearch)
