### PR TITLE
ChartAtom: add new ChartType values

### DIFF
--- a/thrift/src/main/thrift/atoms/chart.thrift
+++ b/thrift/src/main/thrift/atoms/chart.thrift
@@ -3,7 +3,9 @@ namespace java com.gu.contentatom.thrift.atom.chart
 #@namespace scala com.gu.contentatom.thrift.atom.chart
 
 enum ChartType {
-    BAR = 0
+    BAR = 0,
+    LINEDISCRETE = 1,
+    LINECONTINUE = 2
 }
 
 struct Range {

--- a/thrift/src/main/thrift/atoms/chart.thrift
+++ b/thrift/src/main/thrift/atoms/chart.thrift
@@ -5,7 +5,7 @@ namespace java com.gu.contentatom.thrift.atom.chart
 enum ChartType {
     BAR = 0,
     LINEDISCRETE = 1,
-    LINECONTINUE = 2
+    LINE = 2
 }
 
 struct Range {


### PR DESCRIPTION
Adds values to the `ChartType` enum used by the existing `ChartAtom` type. This will allow the chart tool to save line charts in CAPI.

<!-- Your thrift defintions need to also include a scala namespace. It looks like a comment but it's important to have it or generated scala isn't packaged correctly. See the README for more details. -->

<!-- Please ensure you have made corresponding changes to the elasticsearch mappings in CAPI https://git.io/v7cQs ? -->
I don't believe it's necessary to amend the [elasticsearch mappings](https://github.com/guardian/content-api/blob/master/elasticsearch/es-config/templates/atoms-mapping.json#L239) in this case, as the overall structure of the atom has not changed.