### PR TITLE
Update readme - npm package no longer used

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,26 +33,4 @@ $ sbt '+publishLocal'
 ```
 
 ### JavaScript
-
-The JS library should be published to npmjs, see:
-
-https://www.npmjs.com/package/publish
-
-and `npm help publish`.
-
-If you're unfamiliar with publishing on npm the following commands can be useful:
-
-* `npm whoami` - to find out your username (if you have created one)
-* `npm adduser` - to create a user
-* `npm owner ls` - to check the owners of content-atom.
-* `npm owner add <username>` - to add a new owner allowing them to publish content-atom.
-
-But in summary:
-
-1. Bump the version number in `package.json`
-
-2. Make sure you have built the latest version of the JS library with `sbt compile`
-
-3. If you've added another type, be sure to add it to `js/main.js`
-
-4. Then, `npm publish` in the same directory as `package.json`
+Formerly this repo contained a js package that was published to NPM, this is no longer being used: https://www.npmjs.com/package/guardian-contentatom. The module should be deprecated 


### PR DESCRIPTION
According to research and the CAPI team this NPM module is not being used. Therefore we are removing these confusing instructions from the READ.me. 

The package should also be removed at some point.



<!-- Your thrift defintions need to also include a scala namespace. It looks like a comment but it's important to have it or generated scala isn't packaged correctly. See the README for more details. -->

<!-- Please ensure you have made corresponding changes to the elasticsearch mappings in CAPI https://git.io/v7cQs ? -->
