### PR TITLE
Update media.thrift

### DIFF
--- a/thrift/src/main/thrift/atoms/media.thrift
+++ b/thrift/src/main/thrift/atoms/media.thrift
@@ -26,7 +26,8 @@ enum Category {
   NEWS = 3,
   HOSTED = 4, // commercial content supplied by advertiser
   PAID = 5, // commercial content paid for by third-party
-  LIVESTREAM = 6
+  LIVESTREAM = 6,
+  THIRDPARTYCONTENT = 7
 }
 
 /** how a YouTube video can be watched **/


### PR DESCRIPTION
Add a new category for third party content. This is content is for pages like this https://www.theguardian.com/stage/video/2020/apr/06/watch-the-miners-strike-drama-wonderland-by-beth-steel-video which doesn't quite match the pre-existing categories.

<!-- Your thrift defintions need to also include a scala namespace. It looks like a comment but it's important to have it or generated scala isn't packaged correctly. See the README for more details. -->

<!-- Please ensure you have made corresponding changes to the elasticsearch mappings in CAPI https://git.io/v7cQs ? -->
