### PR TITLE
Upgrade the typescript generation plugin.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -81,6 +81,8 @@ lazy val thrift = Project(id = "content-atom-model-thrift", base = file("thrift"
     unmanagedResourceDirectories in Compile += { baseDirectory.value / "src/main/thrift" }
   )
 
+val contentEntityVersion = "2.0.6"
+
 lazy val scalaClasses = Project(id = "content-atom-model", base = file("scala"))
   .settings(commonSettings)
   .settings(
@@ -90,8 +92,8 @@ lazy val scalaClasses = Project(id = "content-atom-model", base = file("scala"))
     scroogeThriftDependencies in Compile ++= Seq("content-entity-thrift"),
     resolvers += Resolver.sonatypeRepo("public"),
     libraryDependencies ++= Seq(
-      "com.gu" % "content-entity-thrift" % "2.0.5",
-      "com.gu" %% "content-entity-model" % "2.0.5",
+      "com.gu" % "content-entity-thrift" % contentEntityVersion,
+      "com.gu" %% "content-entity-model" % contentEntityVersion,
       "org.apache.thrift" % "libthrift" % "0.12.0",
       "com.twitter" %% "scrooge-core" % "20.4.1"
     ),
@@ -118,6 +120,6 @@ lazy val typescriptClasses = (project in file("ts"))
       "content-entity-thrift" -> "@guardian/content-entity-model"
     ),
     libraryDependencies ++= Seq(
-      "com.gu" % "content-entity-thrift" % "2.0.5"
+      "com.gu" % "content-entity-thrift" % contentEntityVersion
     ),
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,4 +9,4 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.7")
 addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "20.4.1")
 
 resolvers += "Guardian Platform Bintray" at "https://dl.bintray.com/guardian/platforms"
-addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.2.0")
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.2.3")


### PR DESCRIPTION
It now publishes `.d.ts` files alongside the compiled `.js` files, rather than `.ts` and `.js` as it was initially set up.

This ensures the client project that consumes the NPM package doesn't get any compilation error coming from the generated library.



<!-- Your thrift defintions need to also include a scala namespace. It looks like a comment but it's important to have it or generated scala isn't packaged correctly. See the README for more details. -->

<!-- Please ensure you have made corresponding changes to the elasticsearch mappings in CAPI https://git.io/v7cQs ? -->
