### PR TITLE
removing bintray resolvers and updating libs to versions published on…

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
-resolvers += Resolver.bintrayRepo("twittercsl", "sbt-plugins")
-
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
@@ -8,5 +6,4 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.7")
 
 addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "20.4.1")
 
-resolvers += "Guardian Platform Bintray" at "https://dl.bintray.com/guardian/platforms"
-addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.2.3")
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.2.7-RC1")


### PR DESCRIPTION
This PR removes two bintray resolvers as bintray is being retired.

- twittercsl - This repository doesnt seem to be required as removing it didnt cause any problems
- guardian - This was used for the sbt-scrooge-typescript which has been updated to a version that is available from maven central. (Wait for a full release)