### PR TITLE
Upgrade dependencies and enable beta builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ npm-debug.log
 generated
 target/
 .idea/
+.bsp/

--- a/README.md
+++ b/README.md
@@ -40,16 +40,17 @@ project typescriptClasses
 releaseNpm <version released to Maven>
 ```
 
-If you need to make a candidate release build available for testing elsewhere, start sbt with
+If you need to make a beta release build available for testing elsewhere, start sbt with
 ```
-$ sbt -DRELEASE_TYPE=candidate
+$ sbt -DRELEASE_TYPE=beta
 ```
-then follow the above release steps as usual. You'll be prompted that this is a CANDIDATE release
-and for a version number that looks like 1.2.3-RCn where n is the candidate build number
+then follow the above release steps as usual. You'll be prompted that this is a BETA release
+and for a version number that looks like 1.2.3-beta.n where n is the beta version number
 you'll specify. This isn't really tracked so make sure it's a new build by checking Maven and NPM first.
 
-When releasing to NPM for typescript, you'll have to manually type the version number to match what you 
-released to Sonatype/Maven for Scala.
+When releasing the typescript classes to NPM, you'll manually type the version number to match what you 
+released to Sonatype/Maven for Scala. Our `sbt-scrooge-typescript` sbt plugin takes care of applying a `--tag beta` 
+to the NPM release when the `RELEASE_TYPE=beta` system property is available.
 
 To cross release locally use
 ```

--- a/README.md
+++ b/README.md
@@ -25,17 +25,31 @@ To release to Maven Central:
 ```sbtshell
 release cross
 ```
-This will release 3 artifacts:
+This will release these artifacts:
 - `content-atom-model-thrift-$version.jar` contains only the Thrift files
 - `content-atom-model_2.13-$version.jar` contains the Thrift files and Scrooge-generated Scala 2.13 classes
 - `content-atom-model_2.12-$version.jar` contains the Thrift files and Scrooge-generated Scala 2.12 classes
-- `content-atom-model_2.11-$version.jar` contains the Thrift files and Scrooge-generated Scala 2.11 classes
+
+Note that support for scala 2.11 ended with scrooge 21.3, so we won't output
+- `content-atom-model_2.11-$version.jar`
+any more.
 
 To release to NPM:
 ```sbtshell
 project typescriptClasses
 releaseNpm <version released to Maven>
 ```
+
+If you need to make a candidate release build available for testing elsewhere, start sbt with
+```
+$ sbt -DRELEASE_TYPE=candidate
+```
+then follow the above release steps as usual. You'll be prompted that this is a CANDIDATE release
+and for a version number that looks like 1.2.3-RCn where n is the candidate build number
+you'll specify. This isn't really tracked so make sure it's a new build by checking Maven and NPM first.
+
+When releasing to NPM for typescript, you'll have to manually type the version number to match what you 
+released to Sonatype/Maven for Scala.
 
 To cross release locally use
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -1,16 +1,16 @@
 import sbtrelease._
 import ReleaseStateTransformations._
 
-val contentEntityVersion = "2.1.0-RC2"
-val scroogeVersion = "21.12.0"
+val contentEntityVersion = "2.2.0-beta.4"
+val scroogeVersion = "22.1.0"   // remember to also update plugins.sbt if the scrooge version changes
 val thriftVersion = "0.15.0"
 
-val candidateReleaseType = "candidate"
-val candidateReleaseSuffix = "-RC1"
+val betaReleaseType = "beta"
+val betaReleaseSuffix = "-beta.0"
 
 lazy val versionSettingsMaybe = {
   sys.props.get("RELEASE_TYPE").map {
-    case v if v == candidateReleaseType => candidateReleaseSuffix
+    case v if v == betaReleaseType => betaReleaseSuffix
   }.map { suffix =>
     releaseVersion := {
       ver => Version(ver).map(_.withoutQualifier.string).map(_.concat(suffix)).getOrElse(versionFormatError(ver))
@@ -66,7 +66,7 @@ lazy val mavenSettings = Seq(
 
 lazy val checkReleaseType: ReleaseStep = ReleaseStep({ st: State =>
   val releaseType = sys.props.get("RELEASE_TYPE").map {
-    case v if v == candidateReleaseType => candidateReleaseType.toUpperCase
+    case v if v == betaReleaseType => betaReleaseType.toUpperCase
   }.getOrElse("PRODUCTION")
 
   SimpleReader.readLine(s"This will be a $releaseType release. Continue? [y/N]: ") match {
@@ -99,18 +99,18 @@ lazy val releaseProcessSteps: Seq[ReleaseStep] = {
   )
 
   /*
-  Release Candidate assemblies can be published to Sonatype and Maven.
+  Beta assemblies can be published to Sonatype and Maven.
 
-  To make this work, start SBT with the candidate RELEASE_TYPE variable set;
-    sbt -DRELEASE_TYPE=candidate
+  To make this work, start SBT with the beta RELEASE_TYPE variable set;
+    sbt -DRELEASE_TYPE=beta
 
   This gets around the "problem" of sbt-sonatype assuming that a -SNAPSHOT build should not be delivered to Maven.
 
-  In this mode, the version number will be presented as e.g. 1.2.3-RC1, but the git tagging and version-updating
+  In this mode, the version number will be presented as e.g. 1.2.3-beta.n, but the git tagging and version-updating
   steps are not triggered, so it's up to the developer to keep track of what was released and manipulate subsequent
   release and next versions appropriately.
   */
-  val candidateSteps: Seq[ReleaseStep] = Seq(
+  val betaSteps: Seq[ReleaseStep] = Seq(
     setReleaseVersion,
     releaseStepCommandAndRemaining("+publishSigned"),
     releaseStepCommand("sonatypeBundleRelease"),
@@ -118,7 +118,7 @@ lazy val releaseProcessSteps: Seq[ReleaseStep] = {
   )
 
   commonSteps ++ (sys.props.get("RELEASE_TYPE") match {
-    case Some(v) if v == candidateReleaseType => candidateSteps // this enables a release candidate build to sonatype and Maven
+    case Some(v) if v == betaReleaseType => betaSteps // this enables a release candidate build to sonatype and Maven
     case None => prodSteps  // our normal deploy route
   })
 
@@ -175,9 +175,19 @@ lazy val scalaClasses = Project(id = "content-atom-model", base = file("scala"))
     Compile / scroogePublishThrift := true
   )
 
+lazy val npmBetaReleaseTagMaybe =
+  sys.props.get("RELEASE_TYPE").map {
+    case v if v == betaReleaseType =>
+      // Why hard-code "beta" instead of using the value of the variable? That's to ensure it's always presented as
+      // --tag beta to the npm release process provided by the ScroogeTypescriptGen plugin regardless of how we identify
+      // a beta release here
+      scroogeTypescriptPublishTag := "beta"
+  }.toSeq
+
 lazy val typescriptClasses = (project in file("ts"))
   .enablePlugins(ScroogeTypescriptGen)
   .settings(commonSettings)
+  .settings(npmBetaReleaseTagMaybe)
   .settings(
     name := "content-atom-typescript",
     scroogeTypescriptNpmPackageName := "@guardian/content-atom-model",

--- a/build.sbt
+++ b/build.sbt
@@ -127,12 +127,13 @@ lazy val releaseProcessSteps: Seq[ReleaseStep] = {
 val commonSettings = Seq(
   organization := "com.gu",
   scalaVersion := "2.13.2",
+  // downgrade scrooge reserved word clashes to warnings
+  Compile / scroogeDisableStrict := true,
   // Scrooge 21.3.0 dropped support for scala < 2.12, so we can only build for Scala 2.12+
   // https://twitter.github.io/scrooge/changelog.html#id11
 	crossScalaVersions := Seq("2.12.11", scalaVersion.value),
   scmInfo := Some(ScmInfo(url("https://github.com/guardian/content-atom"),
                           "scm:git:git@github.com:guardian/content-atom.git")),
-
   releasePublishArtifactsAction := PgpKeys.publishSigned.value,
 ) ++ mavenSettings ++ versionSettingsMaybe
 

--- a/build.sbt
+++ b/build.sbt
@@ -5,79 +5,144 @@ val contentEntityVersion = "2.1.0-RC2"
 val scroogeVersion = "21.12.0"
 val thriftVersion = "0.15.0"
 
-val commonSettings = Seq(
-  organization := "com.gu",
-  scalaVersion := "2.13.2",
-  // Scrooge 21.3.0 dropped support for scala < 2.13, so our builds similarly only support Scala 2.12+
-	crossScalaVersions := Seq("2.12.11", scalaVersion.value),
-  scmInfo := Some(ScmInfo(url("https://github.com/guardian/content-atom"),
-                          "scm:git:git@github.com:guardian/content-atom.git")),
+val candidateReleaseType = "candidate"
+val candidateReleaseSuffix = "-RC1"
 
+lazy val versionSettingsMaybe = {
+  sys.props.get("RELEASE_TYPE").map {
+    case v if v == candidateReleaseType => candidateReleaseSuffix
+  }.map { suffix =>
+    releaseVersion := {
+      ver => Version(ver).map(_.withoutQualifier.string).map(_.concat(suffix)).getOrElse(versionFormatError(ver))
+    }
+  }.toSeq
+}
+
+lazy val mavenSettings = Seq(
   pomExtra := (
-  <url>https://github.com/guardian/content-atom</url>
-  <developers>
-    <developer>
-      <id>paulmr</id>
-      <name>Paul Roberts</name>
-      <url>https://github.com/paulmr</url>
-    </developer>
-    <developer>
-      <id>LATaylor-guardian</id>
-      <name>Luke Taylor</name>
-      <url>https://github.com/LATaylor-guardian</url>
-    </developer>
-    <developer>
-      <id>mchv</id>
-      <name>Mariot Chauvin</name>
-      <url>https://github.com/mchv</url>
-    </developer>
-    <developer>
-      <id>tomrf1</id>
-      <name>Tom Forbes</name>
-      <url>https://github.com/tomrf1</url>
-    </developer>
-    <developer>
-      <id>annebyrne</id>
-      <name>Anne Byrne</name>
-      <url>https://github.com/annebyrne</url>
-    </developer>
-    <developer>
-      <id>regiskuckaertz</id>
-      <name>Regis Kuckaertz</name>
-      <url>https://github.com/regiskuckaertz</url>
-    </developer>
-    <developer>
-      <id>justinpinner</id>
-      <name>Justin Pinner</name>
-      <url>https://github.com/justinpinner</url>
-    </developer>
-  </developers>
+    <url>https://github.com/guardian/content-atom</url>
+      <developers>
+        <developer>
+          <id>paulmr</id>
+          <name>Paul Roberts</name>
+          <url>https://github.com/paulmr</url>
+        </developer>
+        <developer>
+          <id>LATaylor-guardian</id>
+          <name>Luke Taylor</name>
+          <url>https://github.com/LATaylor-guardian</url>
+        </developer>
+        <developer>
+          <id>mchv</id>
+          <name>Mariot Chauvin</name>
+          <url>https://github.com/mchv</url>
+        </developer>
+        <developer>
+          <id>tomrf1</id>
+          <name>Tom Forbes</name>
+          <url>https://github.com/tomrf1</url>
+        </developer>
+        <developer>
+          <id>annebyrne</id>
+          <name>Anne Byrne</name>
+          <url>https://github.com/annebyrne</url>
+        </developer>
+        <developer>
+          <id>regiskuckaertz</id>
+          <name>Regis Kuckaertz</name>
+          <url>https://github.com/regiskuckaertz</url>
+        </developer>
+        <developer>
+          <id>justinpinner</id>
+          <name>Justin Pinner</name>
+          <url>https://github.com/justinpinner</url>
+        </developer>
+      </developers>
   ),
   licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")),
+  publishTo := sonatypePublishToBundle.value,
+  publishConfiguration := publishConfiguration.value.withOverwrite(true)
+)
 
-  publishTo := sonatypePublishTo.value,
-  publishConfiguration := publishConfiguration.value.withOverwrite(true),
-  releasePublishArtifactsAction := PgpKeys.publishSigned.value,
-  releaseProcess := Seq[ReleaseStep](
+lazy val checkReleaseType: ReleaseStep = ReleaseStep({ st: State =>
+  val releaseType = sys.props.get("RELEASE_TYPE").map {
+    case v if v == candidateReleaseType => candidateReleaseType.toUpperCase
+  }.getOrElse("PRODUCTION")
+
+  SimpleReader.readLine(s"This will be a $releaseType release. Continue? [y/N]: ") match {
+    case Some(v) if Seq("Y", "YES").contains(v.toUpperCase) => // we don't care about the value - it's a flow control mechanism
+    case _ => sys.error(s"Release aborted by user!")
+  }
+  // we haven't changed state, just pass it on if we haven't thrown an error from above
+  st
+})
+
+lazy val releaseProcessSteps: Seq[ReleaseStep] = {
+  val commonSteps: Seq[ReleaseStep] = Seq(
+    checkReleaseType,
     checkSnapshotDependencies,
     inquireVersions,
     runClean,
-    runTest,
+    runTest
+  )
+
+  val prodSteps: Seq[ReleaseStep] = Seq(
     setReleaseVersion,
     commitReleaseVersion,
     tagRelease,
     publishArtifacts,
     setNextVersion,
+    releaseStepCommandAndRemaining("+publishSigned"),
+    releaseStepCommand("sonatypeBundleRelease"),
     commitNextVersion,
-    releaseStepCommand("sonatypeRelease"),
     pushChanges
   )
-)
+
+  /*
+  Release Candidate assemblies can be published to Sonatype and Maven.
+
+  To make this work, start SBT with the candidate RELEASE_TYPE variable set;
+    sbt -DRELEASE_TYPE=candidate
+
+  This gets around the "problem" of sbt-sonatype assuming that a -SNAPSHOT build should not be delivered to Maven.
+
+  In this mode, the version number will be presented as e.g. 1.2.3-RC1, but the git tagging and version-updating
+  steps are not triggered, so it's up to the developer to keep track of what was released and manipulate subsequent
+  release and next versions appropriately.
+  */
+  val candidateSteps: Seq[ReleaseStep] = Seq(
+    setReleaseVersion,
+    releaseStepCommandAndRemaining("+publishSigned"),
+    releaseStepCommand("sonatypeBundleRelease"),
+    setNextVersion
+  )
+
+  commonSteps ++ (sys.props.get("RELEASE_TYPE") match {
+    case Some(v) if v == candidateReleaseType => candidateSteps // this enables a release candidate build to sonatype and Maven
+    case None => prodSteps  // our normal deploy route
+  })
+
+}
+
+val commonSettings = Seq(
+  organization := "com.gu",
+  scalaVersion := "2.13.2",
+  // Scrooge 21.3.0 dropped support for scala < 2.12, so we can only build for Scala 2.12+
+  // https://twitter.github.io/scrooge/changelog.html#id11
+	crossScalaVersions := Seq("2.12.11", scalaVersion.value),
+  scmInfo := Some(ScmInfo(url("https://github.com/guardian/content-atom"),
+                          "scm:git:git@github.com:guardian/content-atom.git")),
+
+  releasePublishArtifactsAction := PgpKeys.publishSigned.value,
+) ++ mavenSettings ++ versionSettingsMaybe
 
 lazy val root = Project(id = "root", base = file("."))
-  .aggregate(thrift, scalaClasses)
   .settings(commonSettings)
-  .settings(publishArtifact := false)
+  .aggregate(thrift, scalaClasses)
+  .settings(
+    publishArtifact := false,
+    releaseProcess := releaseProcessSteps
+  )
 
 lazy val thrift = Project(id = "content-atom-model-thrift", base = file("thrift"))
   .settings(commonSettings)
@@ -129,5 +194,5 @@ lazy val typescriptClasses = (project in file("ts"))
     ),
     libraryDependencies ++= Seq(
       "com.gu" % "content-entity-thrift" % contentEntityVersion
-    ),
+    )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbtrelease._
 import ReleaseStateTransformations._
 
-val contentEntityVersion = "2.2.0-beta.4"
+val contentEntityVersion = "2.2.1"
 val scroogeVersion = "22.1.0"   // remember to also update plugins.sbt if the scrooge version changes
 val thriftVersion = "0.15.0"
 

--- a/build.sbt
+++ b/build.sbt
@@ -91,9 +91,9 @@ lazy val releaseProcessSteps: Seq[ReleaseStep] = {
     commitReleaseVersion,
     tagRelease,
     publishArtifacts,
-    setNextVersion,
     releaseStepCommandAndRemaining("+publishSigned"),
     releaseStepCommand("sonatypeBundleRelease"),
+    setNextVersion,
     commitNextVersion,
     pushChanges
   )

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,15 @@
 import sbtrelease._
 import ReleaseStateTransformations._
 
+val contentEntityVersion = "2.1.0-RC2"
+val scroogeVersion = "21.12.0"
+val thriftVersion = "0.15.0"
+
 val commonSettings = Seq(
   organization := "com.gu",
   scalaVersion := "2.13.2",
-	crossScalaVersions := Seq("2.11.12", "2.12.11", scalaVersion.value),
+  // Scrooge 21.3.0 dropped support for scala < 2.13, so our builds similarly only support Scala 2.12+
+	crossScalaVersions := Seq("2.12.11", scalaVersion.value),
   scmInfo := Some(ScmInfo(url("https://github.com/guardian/content-atom"),
                           "scm:git:git@github.com:guardian/content-atom.git")),
 
@@ -41,6 +46,11 @@ val commonSettings = Seq(
       <name>Regis Kuckaertz</name>
       <url>https://github.com/regiskuckaertz</url>
     </developer>
+    <developer>
+      <id>justinpinner</id>
+      <name>Justin Pinner</name>
+      <url>https://github.com/justinpinner</url>
+    </developer>
   </developers>
   ),
   licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")),
@@ -75,30 +85,28 @@ lazy val thrift = Project(id = "content-atom-model-thrift", base = file("thrift"
   .settings(
     description := "Content atom model Thrift files",
     crossPaths := false,
-    publishArtifact in packageDoc := false,
-    publishArtifact in packageSrc := false,
-    includeFilter in unmanagedResources := "*.thrift",
-    unmanagedResourceDirectories in Compile += { baseDirectory.value / "src/main/thrift" }
+    packageDoc / publishArtifact := false,
+    packageSrc / publishArtifact := false,
+    unmanagedResources / includeFilter := "*.thrift",
+    Compile / unmanagedResourceDirectories += { baseDirectory.value / "src/main/thrift" }
   )
-
-val contentEntityVersion = "2.0.6"
 
 lazy val scalaClasses = Project(id = "content-atom-model", base = file("scala"))
   .settings(commonSettings)
   .settings(
     description := "Scala library built from Content-atom thrift definition",
-    scroogeThriftSourceFolder in Compile := baseDirectory.value / "../thrift/src/main/thrift",
-    scroogeThriftOutputFolder in Compile := sourceManaged.value,
-    scroogeThriftDependencies in Compile ++= Seq("content-entity-thrift"),
+    Compile / scroogeThriftSourceFolder := baseDirectory.value / "../thrift/src/main/thrift",
+    Compile / scroogeThriftOutputFolder := sourceManaged.value,
+    Compile / scroogeThriftDependencies ++= Seq("content-entity-thrift"),
     resolvers += Resolver.sonatypeRepo("public"),
     libraryDependencies ++= Seq(
       "com.gu" % "content-entity-thrift" % contentEntityVersion,
       "com.gu" %% "content-entity-model" % contentEntityVersion,
-      "org.apache.thrift" % "libthrift" % "0.12.0",
-      "com.twitter" %% "scrooge-core" % "20.4.1"
+      "org.apache.thrift" % "libthrift" % thriftVersion,
+      "com.twitter" %% "scrooge-core" % scroogeVersion
     ),
     // Include the Thrift file in the published jar
-    scroogePublishThrift in Compile := true
+    Compile / scroogePublishThrift := true
   )
 
 lazy val typescriptClasses = (project in file("ts"))
@@ -111,11 +119,11 @@ lazy val typescriptClasses = (project in file("ts"))
     Test / scroogeDefaultJavaNamespace := scroogeTypescriptNpmPackageName.value,
     description := "Typescript library built from Content-atom thrift definition",
 
-    scroogeLanguages in Compile := Seq("typescript"),
-    scroogeThriftSourceFolder in Compile := baseDirectory.value / "../thrift/src/main/thrift",
+    Compile / scroogeLanguages := Seq("typescript"),
+    Compile / scroogeThriftSourceFolder := baseDirectory.value / "../thrift/src/main/thrift",
 
     scroogeTypescriptPackageLicense := "Apache-2.0",
-    scroogeThriftDependencies in Compile ++= Seq("content-entity-thrift"),
+    Compile / scroogeThriftDependencies ++= Seq("content-entity-thrift"),
     scroogeTypescriptPackageMapping := Map(
       "content-entity-thrift" -> "@guardian/content-entity-model"
     ),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,4 +6,4 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.10")
 
 addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "22.1.0")
 
-addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.6.0-beta.6")
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.6.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,9 @@
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.7")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.10")
 
-addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "21.12.0")
+addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "22.1.0")
 
-addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.5.0-RC1")
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.6.0-beta.6")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,6 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.7")
 
-addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "20.4.1")
+addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "21.12.0")
 
-addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.3.0")
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.5.0-RC1")

--- a/thrift/src/main/thrift/atoms/recipe.thrift
+++ b/thrift/src/main/thrift/atoms/recipe.thrift
@@ -18,19 +18,15 @@ struct Time {
 }
 
 struct Serves {
-  /* note that `from` (field 2) has been renamed `minimum` due to `from` becoming a reserved word in scrooge */
-  /* and that `to` (field 3) is now `maximum` to keep it semantically in line with `from` becoming `minimum` */
   1: required string type
-  2: required i16 minimum
-  3: required i16 maximum
+  2: required i16 from
+  3: required i16 to
   4: optional string unit
 }
 
 struct Range {
-  /* note that `from` (field 1) has been renamed `minimum` due to `from` becoming a reserved word in scrooge */
-  /* and that `to` (field 2) is now `maximum` to keep it semantically in line with `from` becoming `minimum` */
-  1: required i16 minimum
-  2: required i16 maximum
+  1: required i16 from
+  2: required i16 to
 }
 
 struct Ingredient {

--- a/thrift/src/main/thrift/atoms/recipe.thrift
+++ b/thrift/src/main/thrift/atoms/recipe.thrift
@@ -18,15 +18,19 @@ struct Time {
 }
 
 struct Serves {
+  /* note that `from` (field 2) has been renamed `minimum` due to `from` becoming a reserved word in scrooge */
+  /* and that `to` (field 3) is now `maximum` to keep it semantically in line with `from` becoming `minimum` */
   1: required string type
-  2: required i16 from
-  3: required i16 to
+  2: required i16 minimum
+  3: required i16 maximum
   4: optional string unit
 }
 
 struct Range {
-  1: required i16 from
-  2: required i16 to
+  /* note that `from` (field 1) has been renamed `minimum` due to `from` becoming a reserved word in scrooge */
+  /* and that `to` (field 2) is now `maximum` to keep it semantically in line with `from` becoming `minimum` */
+  1: required i16 minimum
+  2: required i16 maximum
 }
 
 struct Ingredient {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.2.5-SNAPSHOT"
+ThisBuild / version := "3.3.0-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "3.3.0-RC2"
+ThisBuild / version := "3.3.0-RC3"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "3.3.0-RC3"
+ThisBuild / version := "3.4.0-beta.2"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "3.3.0-SNAPSHOT"
+ThisBuild / version := "3.3.0-RC2"


### PR DESCRIPTION
# What Changed
We're bumping scrooge and thrift dependencies, which in turn meant we had to update our content-entity dependency too. We are similarly updating the sbt-scrooge-typescript sbt plugin (which is managed by us) and the scrooge-sbt-plugin which is provided by Twitter.

The update to scrooge brought with it an enforced reserved word check on field names, so we're aiming to update the affected fields in as painless and obvious way as possible.

Guidance received suggests that renaming fields is acceptable since it is the IDs of the fields that are critical to maintain compatibility, but we would expect compilation errors to trap any use cases where this isn't true. The overall shape of the data remains unchanged however.

We enabled construction of beta builds and using this branch released;
[3.4.0-beta.0 for scala 2.12](https://repo1.maven.org/maven2/com/gu/content-atom-model_2.12/3.4.0-beta.0/)
[3.4.0-beta.0 for scala 2.13](https://repo1.maven.org/maven2/com/gu/content-atom-model_2.13/3.4.0-beta.0/)
and
[3.4.0-beta.0 for typescript](https://www.npmjs.com/package/@guardian/content-atom-model/v/3.4.0-beta.0)

# How to test
The plan is to put out a beta build of this branch so that we can bring those versions into e.g. content-api-models etc and in turn build and deploy that as a release candidate to make sure it compiles and works as usual wherever it's needed.

In theory this change should not require any updates to our elasticsearch mappings in [CAPI](https://git.io/v7cQs)
