### PR TITLE
Add youtubeOverrideImage to thrift definition

### DIFF
--- a/thrift/src/main/thrift/atoms/media.thrift
+++ b/thrift/src/main/thrift/atoms/media.thrift
@@ -140,4 +140,7 @@ struct MediaAtom {
 
   /** suppress related content of the (optional) Composer page **/
   21: optional bool suppressRelatedContent
+
+  /** optional override (of poster image) for the YouTube thumbnail **/
+  22: optional shared.Image youtubeOverrideImage
 }


### PR DESCRIPTION
Support the new `youtubeOverrideImage` for media atoms. This looks the existing image fields, but will allow users to specify an image to send to YouTube and use as a thumbnail.

Related PRs:
- https://github.com/guardian/content-api/pull/2721
- https://github.com/guardian/media-atom-maker/pull/1077
<!-- Your thrift defintions need to also include a scala namespace. It looks like a comment but it's important to have it or generated scala isn't packaged correctly. See the README for more details. -->

<!-- Please ensure you have made corresponding changes to the elasticsearch mappings in CAPI https://git.io/v7cQs ? -->
