### PR TITLE
Flesh out recipe thrift model

### DIFF
--- a/thrift/src/main/thrift/atoms/recipe.thrift
+++ b/thrift/src/main/thrift/atoms/recipe.thrift
@@ -9,7 +9,6 @@ struct Tags {
   1: required list<string> cuisine
   2: required list<string> category
   3: required list<string> celebration
-  4: required list<string> dietary
 }
 
 struct Time {
@@ -32,9 +31,10 @@ struct Range {
 struct Ingredient {
   1: required string item
   2: optional string comment
-  3: optional double quantity
-  4: optional Range quantityRange
-  5: optional string unit
+  3: required Range quantityRange
+  4: optional string unit
+  5: optional string dietaryInfo
+  6: optional Range caloryRange
 }
 
 struct IngredientsList {
@@ -42,15 +42,22 @@ struct IngredientsList {
   2: required list<Ingredient> ingredients
 }
 
+struct RecipeStep {
+    1: required string name
+    2: required string text
+    3: optional shared.Image image
+    4: optional string link
+}
+
 struct RecipeAtom {
-  /* the unique ID will be stored in the `atom` data */
   1: required string title
-  2: required Tags tags 
-  3: required Time time
-  4: optional Serves serves
-  5: required list<IngredientsList> ingredientsLists
-  6: required list<string> steps
-  7: required list<string> credits
-  8: required list<shared.Image> images
-  9: optional string sourceArticleId
+  2: required string description
+  3: required list<string> authorOrAuthors
+  4: required list<shared.Image> leadImageOrImages
+  5: required Tags tags
+  6: required Time time
+  7: required Serves serves
+  8: required list<IngredientsList> ingredientsLists
+  9: required list<RecipeStep> steps
+  10: optional string canonicalArticleId
 }

--- a/thrift/src/main/thrift/atoms/recipe.thrift
+++ b/thrift/src/main/thrift/atoms/recipe.thrift
@@ -9,7 +9,7 @@ struct Tags {
   1: required list<string> cuisine
   2: required list<string> category
   3: required list<string> celebration
-  // 4: required list<string> dietary
+  4: required list<string> dietary
 }
 
 struct Time {
@@ -37,7 +37,6 @@ struct Ingredient {
   5: optional string unit
   6: optional string dietaryInfo
   7: optional Range caloryRange
-  8: required Range quantityRange
 }
 
 
@@ -47,8 +46,8 @@ struct IngredientsList {
 }
 
 struct RecipeStep {
-    1: required string name
-    2: required string text
+    1: optional string name
+    2: optional string text
     3: optional shared.Image image
     4: optional string link
 }
@@ -59,10 +58,10 @@ struct RecipeAtom {
   3: required Time time
   4: optional Serves serves
   5: required list<IngredientsList> ingredientsLists
-  // 6: required list<string> steps
+  6: required list<string> steps
   7: required list<string> credits
   8: required list<shared.Image> images
   9: optional string sourceArticleId
-  10: required string description
-  11: required list<RecipeStep> steps
+  10: optional string description
+  11: optional list<RecipeStep> recipeSteps
 }

--- a/thrift/src/main/thrift/atoms/recipe.thrift
+++ b/thrift/src/main/thrift/atoms/recipe.thrift
@@ -9,6 +9,7 @@ struct Tags {
   1: required list<string> cuisine
   2: required list<string> category
   3: required list<string> celebration
+  // 4: required list<string> dietary
 }
 
 struct Time {
@@ -31,11 +32,14 @@ struct Range {
 struct Ingredient {
   1: required string item
   2: optional string comment
-  3: required Range quantityRange
-  4: optional string unit
-  5: optional string dietaryInfo
-  6: optional Range caloryRange
+  // 3: optional double quantity
+  4: optional Range quantityRange
+  5: optional string unit
+  6: optional string dietaryInfo
+  7: optional Range caloryRange
+  8: required Range quantityRange
 }
+
 
 struct IngredientsList {
   1: optional string title
@@ -51,13 +55,14 @@ struct RecipeStep {
 
 struct RecipeAtom {
   1: required string title
-  2: required string description
-  3: required list<string> authorOrAuthors
-  4: required list<shared.Image> leadImageOrImages
-  5: required Tags tags
-  6: required Time time
-  7: required Serves serves
-  8: required list<IngredientsList> ingredientsLists
-  9: required list<RecipeStep> steps
-  10: optional string canonicalArticleId
+  2: required Tags tags
+  3: required Time time
+  4: optional Serves serves
+  5: required list<IngredientsList> ingredientsLists
+  // 6: required list<string> steps
+  7: required list<string> credits
+  8: required list<shared.Image> images
+  9: optional string sourceArticleId
+  10: required string description
+  11: required list<RecipeStep> steps
 }


### PR DESCRIPTION
As sketched out with Michel. Part of an ongoing effort to get recipe structured data rendering automatically on any recipe article with a recipe atom on it. 

The goal with this PR is for recipe atoms to have enough detail that they can be used to generate [recipe schema](https://schema.org/Recipe) when rendering pages. Getting to a viable bare minimum requires the following changes:

- More granular step details - title, text, image, and link

Also, with one eye on the work done by Data Tech we've also included nutritional information. It's not needed for bare minimum schema but may well be handy to have further down the line.

# Questions

- Will this automatically translate to the Atom Workshop input UI updating?

<!-- Your thrift defintions need to also include a scala namespace. It looks like a comment but it's important to have it or generated scala isn't packaged correctly. See the README for more details. -->

<!-- Please ensure you have made corresponding changes to the elasticsearch mappings in CAPI https://git.io/v7cQs ? -->
