### PR TITLE
Bump thrift dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ In order for the scala code generated from the thrift definitions to be packaged
 
 ## How to release
 
+### A note on version numbers
+
+The version field in `package.json` should be kept in sync with the version in `version.sbt`
+
+### Prerequisites
+
 Prior to releasing, you will need to ensure that:
  - `tsc` is installed on your machine (e.g. `brew install typescript`)
  - `npm` is installed on your machine
@@ -20,6 +26,8 @@ Prior to releasing, you will need to ensure that:
    this will create/append to an `~/.npmrc` file with the sufficient config
  - you have the followed the [guide](https://docs.google.com/document/d/1rNXjoZDqZMsQblOVXPAIIOMWuwUKe3KzTCttuqS7AcY/edit)
    for publishing to Maven and Sonatype
+
+### Releasing
    
 To release to Maven Central:
 ```sbtshell

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import ReleaseStateTransformations._
 
 val contentEntityVersion = "2.2.1"
 val scroogeVersion = "22.1.0"   // remember to also update plugins.sbt if the scrooge version changes
-val thriftVersion = "0.15.0"
+val thriftVersion = "0.15.0"    // remember to also update package.json if the thrift version changes
 
 val betaReleaseType = "beta"
 val betaReleaseSuffix = "-beta.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "guardian-contentatom",
-  "version": "2.4.62",
+  "version": "3.4.3",
   "description": "Content Atom JavaScript, automatically generated from the Thrift definition.",
   "repository": "https://github.com/guardian/content-atom",
   "main": "js/main.js",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "https://github.com/guardian/content-atom",
   "main": "js/main.js",
   "dependencies": {
-    "thrift": "^0.9.2"
+    "thrift": "^0.15.0"
   },
   "license": "Apache-2.0",
   "files": [

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,2 @@
+// Remember to update the version in package.json if you change this
 ThisBuild / version := "3.4.3-SNAPSHOT"


### PR DESCRIPTION
Chasing down some Snyk complaints related to Thrift < 0.11.0.

This appears to have happened because `package.json` had been neglected during the last update(s).

Have brought this project's own version number in line with `build.sbt` and have added some notes to help keep things aligned in future.

 