### PR TITLE
Resync package.json version with expected next release 3.4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "guardian-contentatom",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "description": "Content Atom JavaScript, automatically generated from the Thrift definition.",
   "repository": "https://github.com/guardian/content-atom",
   "main": "js/main.js",


### PR DESCRIPTION
We're about to release this - just had to nudge the version in `package.json` first.