### PR TITLE
Add aspect ratio to the media atom model

### DIFF
--- a/thrift/src/main/thrift/atoms/media.thrift
+++ b/thrift/src/main/thrift/atoms/media.thrift
@@ -43,6 +43,7 @@ struct Asset {
   3: required string id
   4: required Platform platform
   5: optional string mimeType
+  6: optional string aspectRatio
 }
 
 struct PlutoData {


### PR DESCRIPTION

<!-- Your thrift defintions need to also include a scala namespace. It looks like a comment but it's important to have it or generated scala isn't packaged correctly. See the README for more details. -->

<!-- Please ensure you have made corresponding changes to the elasticsearch mappings in CAPI https://git.io/v7cQs ? -->
