### PR TITLE
Release via GitHub actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,70 @@
+name: Release Sonatype
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release_snapshot_sonatype:
+    if: "github.event.release.prerelease"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          base: main  #see https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#pull-request-events
+      - uses: actions/setup-java@v3
+        with:
+          distribution: corretto
+          java-version: 11
+          cache: sbt
+      - name: Release Snapshot (prerelease) to Sonatype
+        run: |
+          VERSION=$(git describe --tags | cut -f2 -d"@")
+          if [[ ${VERSION:0:1} == "v" ]] ; then
+            VERSION=${VERSION:1}
+          fi
+          if [[ ${VERSION: -9} != "-SNAPSHOT" ]] ; then
+            echo "Version must end in -SNAPSHOT. Adding -SNAPSHOT suffix"
+            VERSION="$VERSION-SNAPSHOT"
+          fi
+          echo $PGP_SECRET | base64 --decode | gpg --batch --import
+          export GPG_TTY=$(tty)
+          echo "Releasing version $VERSION Sonatype as snapshot"
+          yes | sbt -DRELEASE_TYPE=snapshot "clean" "release cross release-version $VERSION with-defaults"
+        env:
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+
+  release_production_sonatype:
+    if: "! github.event.release.prerelease"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          base: main  #see https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#pull-request-events
+      - uses: actions/setup-java@v3
+        with:
+          distribution: corretto
+          java-version: 11
+          cache: sbt
+      - name: Release Production to Sonatype
+        run: |
+          VERSION=$(git describe --tags | cut -f2 -d"@")
+          if [[ ${VERSION:0:1} == "v" ]] ; then
+            VERSION=${VERSION:1}
+          fi
+          if [[ ${VERSION: -9} == "-SNAPSHOT" ]] ; then
+            echo "Version must NOT end in -SNAPSHOT."
+            exit 1
+          fi
+          echo $PGP_SECRET | base64 --decode | gpg --batch --import
+          export GPG_TTY=$(tty)
+          echo "Releasing version $VERSION Sonatype as production"
+          yes | sbt -DRELEASE_TYPE=production "clean" "release cross release-version $VERSION with-defaults"
+        env:
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/build.sbt
+++ b/build.sbt
@@ -5,89 +5,32 @@ val contentEntityVersion = "2.2.1"
 val scroogeVersion = "22.1.0"   // remember to also update plugins.sbt if the scrooge version changes
 val thriftVersion = "0.15.0"    // remember to also update package.json if the thrift version changes
 
-val betaReleaseType = "beta"
-val betaReleaseSuffix = "-beta.0"
-
-lazy val versionSettingsMaybe = {
-  sys.props.get("RELEASE_TYPE").map {
-    case v if v == betaReleaseType => betaReleaseSuffix
-  }.map { suffix =>
-    releaseVersion := {
-      ver => Version(ver).map(_.withoutQualifier.string).map(_.concat(suffix)).getOrElse(versionFormatError(ver))
-    }
-  }.toSeq
-}
+//https://github.com/xerial/sbt-sonatype/issues/103
+publishTo := sonatypePublishToBundle.value
 
 lazy val mavenSettings = Seq(
-  pomExtra := (
-    <url>https://github.com/guardian/content-atom</url>
-      <developers>
-        <developer>
-          <id>paulmr</id>
-          <name>Paul Roberts</name>
-          <url>https://github.com/paulmr</url>
-        </developer>
-        <developer>
-          <id>LATaylor-guardian</id>
-          <name>Luke Taylor</name>
-          <url>https://github.com/LATaylor-guardian</url>
-        </developer>
-        <developer>
-          <id>mchv</id>
-          <name>Mariot Chauvin</name>
-          <url>https://github.com/mchv</url>
-        </developer>
-        <developer>
-          <id>tomrf1</id>
-          <name>Tom Forbes</name>
-          <url>https://github.com/tomrf1</url>
-        </developer>
-        <developer>
-          <id>annebyrne</id>
-          <name>Anne Byrne</name>
-          <url>https://github.com/annebyrne</url>
-        </developer>
-        <developer>
-          <id>regiskuckaertz</id>
-          <name>Regis Kuckaertz</name>
-          <url>https://github.com/regiskuckaertz</url>
-        </developer>
-        <developer>
-          <id>justinpinner</id>
-          <name>Justin Pinner</name>
-          <url>https://github.com/justinpinner</url>
-        </developer>
-      </developers>
-  ),
   licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")),
   publishTo := sonatypePublishToBundle.value,
   publishConfiguration := publishConfiguration.value.withOverwrite(true)
 )
 
-lazy val checkReleaseType: ReleaseStep = ReleaseStep({ st: State =>
-  val releaseType = sys.props.get("RELEASE_TYPE").map {
-    case v if v == betaReleaseType => betaReleaseType.toUpperCase
-  }.getOrElse("PRODUCTION")
-
-  SimpleReader.readLine(s"This will be a $releaseType release. Continue? [y/N]: ") match {
-    case Some(v) if Seq("Y", "YES").contains(v.toUpperCase) => // we don't care about the value - it's a flow control mechanism
-    case _ => sys.error(s"Release aborted by user!")
-  }
-  // we haven't changed state, just pass it on if we haven't thrown an error from above
-  st
-})
+val snapshotReleaseType = "snapshot"
 
 lazy val releaseProcessSteps: Seq[ReleaseStep] = {
   val commonSteps: Seq[ReleaseStep] = Seq(
-    checkReleaseType,
     checkSnapshotDependencies,
     inquireVersions,
     runClean,
-    runTest
+    runTest,
+    setReleaseVersion
+  )
+
+  val snapshotSteps: Seq[ReleaseStep] = Seq(
+    publishArtifacts,
+    releaseStepCommand("sonatypeReleaseAll")
   )
 
   val prodSteps: Seq[ReleaseStep] = Seq(
-    setReleaseVersion,
     commitReleaseVersion,
     tagRelease,
     publishArtifacts,
@@ -95,33 +38,19 @@ lazy val releaseProcessSteps: Seq[ReleaseStep] = {
     releaseStepCommand("sonatypeBundleRelease"),
     setNextVersion,
     commitNextVersion,
-    pushChanges
   )
 
-  /*
-  Beta assemblies can be published to Sonatype and Maven.
 
-  To make this work, start SBT with the beta RELEASE_TYPE variable set;
-    sbt -DRELEASE_TYPE=beta
-
-  This gets around the "problem" of sbt-sonatype assuming that a -SNAPSHOT build should not be delivered to Maven.
-
-  In this mode, the version number will be presented as e.g. 1.2.3-beta.n, but the git tagging and version-updating
-  steps are not triggered, so it's up to the developer to keep track of what was released and manipulate subsequent
-  release and next versions appropriately.
-  */
-  val betaSteps: Seq[ReleaseStep] = Seq(
-    setReleaseVersion,
-    releaseStepCommandAndRemaining("+publishSigned"),
-    releaseStepCommand("sonatypeBundleRelease"),
-    setNextVersion
+  val localPostRelease: Seq[ReleaseStep] = Seq(
+    pushChanges,
   )
 
-  commonSteps ++ (sys.props.get("RELEASE_TYPE") match {
-    case Some(v) if v == betaReleaseType => betaSteps // this enables a release candidate build to sonatype and Maven
-    case None => prodSteps  // our normal deploy route
-  })
-
+  (sys.props.get("RELEASE_TYPE"), sys.env.get("CI")) match {
+    case (Some(v), None) if v == snapshotReleaseType => commonSteps ++ snapshotSteps ++ localPostRelease
+    case (_, None) => commonSteps ++ prodSteps ++ localPostRelease
+    case (Some(v), _) if v == snapshotReleaseType => commonSteps ++ snapshotSteps
+    case (_, _) => commonSteps ++ prodSteps
+  }
 }
 
 val commonSettings = Seq(
@@ -135,7 +64,7 @@ val commonSettings = Seq(
   scmInfo := Some(ScmInfo(url("https://github.com/guardian/content-atom"),
                           "scm:git:git@github.com:guardian/content-atom.git")),
   releasePublishArtifactsAction := PgpKeys.publishSigned.value,
-) ++ mavenSettings ++ versionSettingsMaybe
+) ++ mavenSettings
 
 lazy val root = Project(id = "root", base = file("."))
   .settings(commonSettings)
@@ -175,19 +104,10 @@ lazy val scalaClasses = Project(id = "content-atom-model", base = file("scala"))
     Compile / scroogePublishThrift := true
   )
 
-lazy val npmBetaReleaseTagMaybe =
-  sys.props.get("RELEASE_TYPE").map {
-    case v if v == betaReleaseType =>
-      // Why hard-code "beta" instead of using the value of the variable? That's to ensure it's always presented as
-      // --tag beta to the npm release process provided by the ScroogeTypescriptGen plugin regardless of how we identify
-      // a beta release here
-      scroogeTypescriptPublishTag := "beta"
-  }.toSeq
 
 lazy val typescriptClasses = (project in file("ts"))
   .enablePlugins(ScroogeTypescriptGen)
   .settings(commonSettings)
-  .settings(npmBetaReleaseTagMaybe)
   .settings(
     name := "content-atom-typescript",
     scroogeTypescriptNpmPackageName := "@guardian/content-atom-model",

--- a/build.sbt
+++ b/build.sbt
@@ -17,39 +17,41 @@ lazy val mavenSettings = Seq(
 val snapshotReleaseType = "snapshot"
 
 lazy val releaseProcessSteps: Seq[ReleaseStep] = {
-  val commonSteps: Seq[ReleaseStep] = Seq(
+  val commonSteps:Seq[ReleaseStep] = Seq(
     checkSnapshotDependencies,
     inquireVersions,
     runClean,
     runTest,
-    setReleaseVersion
+    setReleaseVersion,
   )
 
-  val snapshotSteps: Seq[ReleaseStep] = Seq(
+  val localExtraSteps:Seq[ReleaseStep] = Seq(
+    commitReleaseVersion,
+    tagRelease,
+    publishArtifacts,
+    setNextVersion,
+    commitNextVersion
+  )
+
+  val snapshotSteps:Seq[ReleaseStep] = Seq(
     publishArtifacts,
     releaseStepCommand("sonatypeReleaseAll")
   )
 
-  val prodSteps: Seq[ReleaseStep] = Seq(
-    commitReleaseVersion,
-    tagRelease,
-    publishArtifacts,
+  val prodSteps:Seq[ReleaseStep] = Seq(
     releaseStepCommandAndRemaining("+publishSigned"),
-    releaseStepCommand("sonatypeBundleRelease"),
-    setNextVersion,
-    commitNextVersion,
+    releaseStepCommand("sonatypeBundleRelease")
   )
 
-
-  val localPostRelease: Seq[ReleaseStep] = Seq(
+  val localPostRelease:Seq[ReleaseStep]  = Seq(
     pushChanges,
   )
 
   (sys.props.get("RELEASE_TYPE"), sys.env.get("CI")) match {
-    case (Some(v), None) if v == snapshotReleaseType => commonSteps ++ snapshotSteps ++ localPostRelease
-    case (_, None) => commonSteps ++ prodSteps ++ localPostRelease
+    case (Some(v), None) if v == snapshotReleaseType => commonSteps ++ localExtraSteps ++ snapshotSteps ++ localPostRelease
+    case (_, None) => commonSteps ++ localExtraSteps ++ prodSteps ++ localPostRelease
     case (Some(v), _) if v == snapshotReleaseType => commonSteps ++ snapshotSteps
-    case (_, _) => commonSteps ++ prodSteps
+    case (_, _)=> commonSteps ++ prodSteps
   }
 }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.7
+sbt.version=1.9.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,7 @@
-addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
-
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
-
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.10")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 
 addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "22.1.0")
 


### PR DESCRIPTION
Following the example of `content-api-firehose-client' attempt to release via GitHub actions.

Regression of Beta releases while trying to work this out =(