### PR TITLE
Adopt gha-scala-rel-workflow in the project

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
     secrets:
       SONATYPE_PASSWORD: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD }}
       PGP_PRIVATE_KEY: ${{ secrets.AUTOMATED_MAVEN_RELEASE_PGP_SECRET }}
+      GITHUB_APP_PRIVATE_KEY: ${{ secrets.AUTOMATED_MAVEN_RELEASE_GITHUB_APP_PRIVATE_KEY }}
 
   typescript-npm-release:
     name: NPM Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           registry-url: https://registry.npmjs.org
       - name: Release Typescript to NPM
         run: |
-          sbt "project typescript" "releaseNpm ${{ needs.scala-maven-release.outputs.RELEASE_VERSION }}"
+          sbt "project typescriptClasses" "releaseNpm ${{ needs.scala-maven-release.outputs.RELEASE_VERSION }}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           RELEASE_TYPE: ${{ needs.scala-maven-release.outputs.RELEASE_TYPE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,76 +1,35 @@
-name: Release Sonatype
+name: Release
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
 
 jobs:
-  release_snapshot_sonatype:
-    if: "github.event.release.prerelease"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          base: main  #see https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#pull-request-events
-      - uses: actions/setup-java@v3
-        with:
-          distribution: corretto
-          java-version: 11
-          cache: sbt
-      - name: Release Snapshot (prerelease) to Sonatype
-        run: |
-          VERSION=$(git describe --tags | cut -f2 -d"@")
-          if [[ ${VERSION:0:1} == "v" ]] ; then
-            VERSION=${VERSION:1}
-          fi
-          if [[ ${VERSION: -9} != "-SNAPSHOT" ]] ; then
-            echo "Version must end in -SNAPSHOT. Adding -SNAPSHOT suffix"
-            VERSION="$VERSION-SNAPSHOT"
-          fi
-          echo $PGP_SECRET | base64 --decode | gpg --batch --import
-          export GPG_TTY=$(tty)
-          echo "Releasing version $VERSION Sonatype as snapshot"
-          yes | sbt -DRELEASE_TYPE=snapshot "clean" "release cross release-version $VERSION with-defaults"
-        env:
-          PGP_SECRET: ${{ secrets.PGP_SECRET }}
-          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+  scala-maven-release:
+    name: Maven Release
+    uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@main
+    permissions: { contents: write, pull-requests: write }
+    secrets:
+      SONATYPE_PASSWORD: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD }}
+      PGP_PRIVATE_KEY: ${{ secrets.AUTOMATED_MAVEN_RELEASE_PGP_SECRET }}
 
-  release_production_sonatype:
-    if: "! github.event.release.prerelease"
+  typescript-npm-release:
+    name: NPM Release
+    needs: scala-maven-release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          base: main  #see https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#pull-request-events
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           distribution: corretto
           java-version: 11
           cache: sbt
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
           registry-url: https://registry.npmjs.org
-      - name: Release Production to Sonatype and NPM
+      - name: Release Typescript to NPM
         run: |
-          VERSION=$(git describe --tags | cut -f2 -d"@")
-          if [[ ${VERSION:0:1} == "v" ]] ; then
-            VERSION=${VERSION:1}
-          fi
-          if [[ ${VERSION: -9} == "-SNAPSHOT" ]] ; then
-            echo "Version must NOT end in -SNAPSHOT."
-            exit 1
-          fi
-          echo $PGP_SECRET | base64 --decode | gpg --batch --import
-          export GPG_TTY=$(tty)
-          echo "Releasing version $VERSION Sonatype as production"
-
-          yes | sbt -DRELEASE_TYPE=production "clean" "release cross release-version $VERSION with-defaults" "project typescriptClasses" "releaseNpm $VERSION"
+          sbt "project typescript" "releaseNpm ${{ needs.scala-maven-release.outputs.RELEASE_VERSION }}"
         env:
-          PGP_SECRET: ${{ secrets.PGP_SECRET }}
-          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          RELEASE_TYPE: ${{ needs.scala-maven-release.outputs.RELEASE_TYPE }}

--- a/README.md
+++ b/README.md
@@ -9,26 +9,8 @@ This is the Thrift definition of the Content Atom model, and the published versi
 In order for the scala code generated from the thrift definitions to be packaged correctly a scala namespace needs to be included. For example for the chart atom this would be:
 `#@namespace scala com.gu.contentatom.thrift.atom.chart`
 
-## How to release
 
-### A note on version numbers
-
-The version field in `package.json` should be kept in sync with the version in `version.sbt`
-
-### Prerequisites
-
-Prior to releasing, you will need to ensure that:
- - `tsc` is installed on your machine (e.g. `brew install typescript`)
- - `npm` is installed on your machine
- - you have an NPM account which is part of the [@guardian](https://www.npmjs.com/org/guardian) org
- - you have configured an NPM [access token](https://docs.npmjs.com/creating-and-viewing-authentication-tokens) to 
-   publish to @guardian; a convenient way to set this up is to execute `npm login` locally and follow the prompts;
-   this will create/append to an `~/.npmrc` file with the sufficient config
- - you have the followed the [guide](https://docs.google.com/document/d/1rNXjoZDqZMsQblOVXPAIIOMWuwUKe3KzTCttuqS7AcY/edit)
-   for publishing to Maven and Sonatype
-
-
-#### How to make releases (maven and npm):
+## How to make releases (maven and npm):
 
 This repo uses [`gha-scala-library-release-workflow`](https://github.com/guardian/gha-scala-library-release-workflow)
 to automate publishing releases (both full & preview releases) - see

--- a/README.md
+++ b/README.md
@@ -28,45 +28,8 @@ Prior to releasing, you will need to ensure that:
    for publishing to Maven and Sonatype
 
 
-#### Non-production releases (Sonatype only):
+#### How to make releases (maven and npm):
 
-The easiest way to release a snapshot version is via the github UI.
-[This](https://github.com/guardian/content-api-firehose-client/pull/28/373) PR introduced the ability to use a github action to trigger the release.
-
-The steps you should take are:
-- Push the branch with the changes you want to release to Github.
-- [Click here](https://github.com/guardian/content-api-firehose-client/releases/new?prerelease=true) to create prerelease using Github releases.
-
-- You must then:
-- Set the Target to your branch.
-- Create a tag for the snapshot release (the tag can be created from this same UI if it doesn't already exist).
-- The tag should ideally have format "vX.X.X-SNAPSHOT".
-- Double-check that the "Set as pre-release" box is ticket.
-- To automatically release the snapshot to sonatype then click the "Publish release" button.
-
-And then manually release the npm module:
-`npm i -g typescript && sbt 'project typescriptClasses; releaseNpm X.X.X-SNAPSHOT'`
-
-
-#### Production releases (Sonatype and NPM):
-
-When your changes are done and tested and you're ready to release a new production version, edit the `version.sbt` file to reflect the version you are about to release.
-
-Typically this should just require the removal of the -SNAPSHOT part, but check in [maven](https://repo1.maven.org/maven2/com/gu/content-api-firehose-client_2.13/) to make sure nobody else has released this version before you.
-
-Open a PR.
-
-When your PR is approved, merge it to `main` and ensure the build actions complete successfully.
-
-Then, on the [releases](https://github.com/guardian/content-api-firehose-client/releases) page:
-- Choose `Draft a new release`
-- Create a new tag of the version number e.g. `v1.0.10`
-- Set the target to the `main` branch
-- Add a release title (the version number again is fine)
-- Add an optional description
-- Ensure that `Set as pre-release` is **unchecked**
-- Click the `Publish release` button
-
-When the release process has finished, pull the updated `main` branch locally and update the `version.sbt` file to reflect the next build number, e.g. `1.0.11-SNAPSHOT` and commit that directly back to `main` - there's no need to open a PR for that.
-
-When your release shows up on [maven](https://repo1.maven.org/maven2/com/gu/content-api-firehose-client_2.13/) the updated version can be referenced in client code.
+This repo uses [`gha-scala-library-release-workflow`](https://github.com/guardian/gha-scala-library-release-workflow)
+to automate publishing releases (both full & preview releases) - see
+[**Making a Release**](https://github.com/guardian/gha-scala-library-release-workflow/blob/main/docs/making-a-release.md).

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.7
+sbt.version=1.9.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,11 @@
-addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.10")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.10.0")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
-addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
-
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.4.0")
 addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "22.1.0")
-
 addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.6.0")
+addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.0")
+
+
+
+
+


### PR DESCRIPTION
**Changes**

Implementing `gha-scala-release-workflow` process ref: https://github.com/guardian/gha-scala-library-release-workflow/blob/main/docs/configuration.md
to have release process with organisation based secrets, more secured, less code for maintainability, easy to deploy on both maven and npm.

Since it requires release on npm as well. We have taken npm release changes from content-api-models ref:https://github.com/guardian/content-api-models/blob/main/.github/workflows/release.yml
