### PR TITLE
Bump content-entity's latest release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbtrelease._
 import ReleaseStateTransformations._
 
-val contentEntityVersion = "2.2.1"
+val contentEntityVersion = "3.0.3"
 val scroogeVersion = "22.1.0"   // remember to also update plugins.sbt if the scrooge version changes
 val thriftVersion = "0.15.0"    // remember to also update package.json if the thrift version changes
 


### PR DESCRIPTION
We have got latest release of `content-entity` after implementing `gha-scala-library-release`
This PR will bump that version and test as well.