### PR TITLE
Update branch to main from master in snyk workflow

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -3,7 +3,7 @@ name: Snyk
 on:
   push:
     branches:
-      - master
+      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The default branch of this repository has been updated to main, but the branch name was not updated in this workflow. This means the workflow hasn’t been running when commits have been merged to main (e.g. if you look at the builds on [the last commit to main on github](https://github.com/guardian/content-atom/commit/bb1b98e04469498fa83c3e4b70f76b0d03c512ba), there’s no run of the snyk workflow).

As such, our dependency vulnerability notifications haven’t been up to date! This commit updates the branch name so that the notifications will be up to date.