### PR TITLE
Add setup-sbt to workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup JDK
-        uses: actions/setup-java@v4
-        with:
-          distribution: corretto
-          java-version: 11
-          cache: sbt
+      - uses: sbt/setup-sbt@v1.1.0
       - name: Build # and "Test" to apply after having some tests
         run: sbt compile
       - name: Test Summary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,11 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
-        with:
-          distribution: corretto
-          java-version: 11
-          cache: sbt
+      - uses: sbt/setup-sbt@v1.1.0
       - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc


### PR DESCRIPTION
## What does this change?

Adds `setup-sbt` to workflow

Note that `setup-scala` was not used due to a discrepancy between the `java-version` in `setup-java` and that in the pre-existing `.tool-versions` file

## How to test

Workflow ran successfully on this branch

## How can we measure success?

No failing workflows when Github takes sbt away from us!
<!-- Your thrift defintions need to also include a scala namespace. It looks like a comment but it's important to have it or generated scala isn't packaged correctly. See the README for more details. -->

<!-- Please ensure you have made corresponding changes to the elasticsearch mappings in CAPI https://git.io/v7cQs ? -->
