### PR TITLE
Add Subtitles asset type

### DIFF
--- a/thrift/src/main/thrift/atoms/media.thrift
+++ b/thrift/src/main/thrift/atoms/media.thrift
@@ -17,7 +17,8 @@ enum Platform {
 
 enum AssetType {
   AUDIO = 0,
-  VIDEO = 1
+  VIDEO = 1,
+  SUBTITLES = 2
 }
 
 enum Category {


### PR DESCRIPTION
### Why are we doing this?
We are adding subtitles to loops. The intended solution is to provide an m3u8 which has an internal reference to a vtt file, but we want to fallback to providing an mp4 alongside the standalone vtt file. To do so we need to extend the AssetType model of the Media atom.

### Is this future proof?
We considered that in future, we might also want to model a Captions asset type. We debated whether a Text asset type would be more generic, but we would then have to add an optional field on the Asset to handle whether it was Captions or Subtitles (which would be awkward as it wouldn't apply to videos and audio).

We also discussed how we could model the language of the subtitles. We could model this directly on the Asset, rather than AssetType. A Language field could just as easily apply to Video and Audio as it would to Subtitles. This is not needed for now - but you never know!

For these reasons we think going for a Subtitles AssetType is a suitable approach - it meets the current needs and is future compatible (we can always add a fourth type, Captions, if we ever need to disambiguate between Captions and Subtitles).
