### PR TITLE
Add new looping video boolean field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ generated
 target/
 .idea/
 .bsp/
+.DS_Store
+thrift/.DS_Store

--- a/thrift/src/main/thrift/atoms/media.thrift
+++ b/thrift/src/main/thrift/atoms/media.thrift
@@ -144,4 +144,7 @@ struct MediaAtom {
 
   /** optional override (of poster image) for the YouTube thumbnail **/
   22: optional shared.Image youtubeOverrideImage
+
+  /** allow the (looping) video to autoplay in articles **/
+  23: optional bool autoloopVideoOnPageLoad
 }


### PR DESCRIPTION
## What does this change?
A small update to add a new boolean field to the media model.

For reference, see the commissioning issue in the Arts & Pubs team space: https://github.com/guardian/articles-and-publishing/issues/71

## How to test
TODO: find out how this change gets tested
