### PR TITLE
Use v2 of `gha-scala-library-release-workflow`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,10 @@
 name: Release
-
-on:
-  workflow_dispatch:
+on: workflow_dispatch
 
 jobs:
   scala-maven-release:
     name: Maven Release
-    uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@v1
+    uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@v2
     permissions: { contents: write, pull-requests: write }
     secrets:
       SONATYPE_TOKEN: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_TOKEN }}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,5 @@
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.10.0")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.4.0")
 addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "22.1.0")
 addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.6.0")
-addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.0")
-
-
-
-
-
+addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.1")


### PR DESCRIPTION
https://github.com/guardian/gha-scala-library-release-workflow/releases/tag/v2.0.0

We no longer need to include `sbt-sonatype` in our project, thanks to this PR, included in v2:

* guardian/gha-scala-library-release-workflow#62
