### PR TITLE
Add hasAudio to media atom assets

### DIFF
--- a/thrift/src/main/thrift/atoms/media.thrift
+++ b/thrift/src/main/thrift/atoms/media.thrift
@@ -64,6 +64,8 @@ struct Asset {
   6: optional shared.ImageAssetDimensions dimensions
   /** video only: width:height ratio of the video frame **/
   7: optional string aspectRatio
+  /** video only: if a video has non-silent audio tracks **/
+  8: optional bool hasAudio
 }
 
 struct PlutoData {


### PR DESCRIPTION
Adds an hasAudio boolean property to the assets model. 

This allows MAM to expose if an asset has audio or not which willallow downstream platforms to more easily read this information and render controls as appropriate. 