### PR TITLE
Adds duration and hasAudio attributes to media assets

### DIFF
--- a/thrift/src/main/thrift/atoms/media.thrift
+++ b/thrift/src/main/thrift/atoms/media.thrift
@@ -65,6 +65,9 @@ struct Asset {
   /** video only: width:height ratio of the video frame **/
   7: optional string aspectRatio
   8: optional i64 duration // seconds
+  /** video only: if a video has non-silent audio tracks **/
+  9: optional bool hasAudio
+
 }
 
 struct PlutoData {

--- a/thrift/src/main/thrift/atoms/media.thrift
+++ b/thrift/src/main/thrift/atoms/media.thrift
@@ -64,6 +64,7 @@ struct Asset {
   6: optional shared.ImageAssetDimensions dimensions
   /** video only: width:height ratio of the video frame **/
   7: optional string aspectRatio
+  8: optional i64 duration // seconds
 }
 
 struct PlutoData {


### PR DESCRIPTION
<!-- Your thrift defintions need to also include a scala namespace. It looks like a comment but it's important to have it or generated scala isn't packaged correctly. See the README for more details. -->

<!-- Please ensure you have made corresponding changes to the elasticsearch mappings in CAPI https://git.io/v7cQs ? -->
This change adds two new fields to the media assets:

1. a `duration` attribute. This is intended to support setting a media atom's existing duration value when activated in MAM (Media Atom Maker):

https://github.com/guardian/content-atom/blob/f581992f617fc7bbbf55b70811f47092b9a14460/thrift/src/main/thrift/atoms/media.thrift#L140

When a video is uploaded via MAM and self hosted, the AWS Transcoder step allows us to easily determine the duration of the provided video. However, when we later go to activate the chosen asset, the duration is not available. This change allows the duration to be persisted to the MAM's DynamoDB table and used when activating an asset to set the Atom's duration.

2. a `hasAudio` attribute. This attribute indicates whether a video contains non-silent audio and is intended for use by downstream rendering platforms (e.g. to determine whether audio controls should be shown in the player).

When a video is uploaded via MAM for self-hosting, ffmpeg analyses the audio track:

- If non-silent audio is detected, the audio track is preserved during transcoding.
- If the audio is silent or effectively empty, the audio track is removed before transcoding.

The hasAudio field persists the outcome of this process on the atom, allowing clients to reliably determine whether usable audio is present without needing to inspect the media itself on the fly.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214024821512601
  - https://app.asana.com/0/0/1213896928539813
  

## Relevant PRs

- [content-atom](https://github.com/guardian/content-atom/pull/208) <- you are here
- [atom-maker](https://github.com/guardian/atom-maker/pull/141)
- [content-api (ES mappings)](https://github.com/guardian/content-api/pull/3335)
- [content-api (Porter)](https://github.com/guardian/content-api/pull/3336)
- [content-api-models](https://github.com/guardian/content-api-models/pull/297)
- [content-api (Concierge)](https://github.com/guardian/content-api/pull/3337)
