### PR TITLE
Additional field for the version of an audio file with ads

### DIFF
--- a/thrift/src/main/thrift/atoms/audio.thrift
+++ b/thrift/src/main/thrift/atoms/audio.thrift
@@ -35,4 +35,8 @@ struct AudioAtom {
 
   // Off-platform links
   6: optional OffPlatform offPlatformLinks
+
+  // MP3 audio track with ads. We don't support other formats. 
+  // If this is absent, concierge may add it in
+  7: optional string trackUrlWithAds
 }


### PR DESCRIPTION
This will allow us to bring some ad logic upstream to concierge.

See also https://github.com/guardian/content-api-models/pull/298 which covers element (rather than atom) audio components.