### PR TITLE
Add tags to atoms

### DIFF
--- a/thrift/src/main/thrift/contentatom.thrift
+++ b/thrift/src/main/thrift/contentatom.thrift
@@ -110,6 +110,7 @@ struct Atom {
   7: optional Flags flags
   8: optional string title
   9: optional list<string> commissioningDesks = []
+  10: optional list<string> tagIds = []
  }
 
 enum EventType {


### PR DESCRIPTION

<!-- Your thrift defintions need to also include a scala namespace. It looks like a comment but it's important to have it or generated scala isn't packaged correctly. See the README for more details. -->

This pull request adds a new property for a list of tag IDs to atoms as part of our work on making atoms taggable. The motivation is to improve data analysis using tracking data from data lake by splitting data based on the tags associated with the atom.

For this purpose, we just need the tag IDs on the atom.  To avoid increasing the complexity of the work unnecessarily (particularly as this thrift model is shared between the tools and the CAPI Concierge), we simply add a list of tag IDs as strings to the atom model.

<!-- Please ensure you have made corresponding changes to the elasticsearch mappings in CAPI https://git.io/v7cQs ? -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214427212548853