### PR TITLE
Fix npm publishing, update sbt-scrooge-typescript, fix npm publish for preview & update TypeScript

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -72,10 +72,14 @@ lazy val scalaClasses = Project(id = "content-atom-model", base = file("scala"))
     Compile / scroogePublishThrift := true
   )
 
+lazy val npmPreviewReleaseTagMaybe = if (sys.env.get("RELEASE_TYPE").contains("PREVIEW_FEATURE_BRANCH")) {
+  Seq(scroogeTypescriptPublishTag := "preview")
+} else Seq.empty
 
 lazy val typescriptClasses = (project in file("ts"))
   .enablePlugins(ScroogeTypescriptGen)
   .settings(artifactProductionSettings)
+  .settings(npmPreviewReleaseTagMaybe)
   .settings(
     name := "content-atom-typescript",
     scroogeTypescriptNpmPackageName := "@guardian/content-atom-model",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "thrift": "^0.20.0"
       },
       "devDependencies": {
-        "typescript": "^4.5.4"
+        "typescript": "^5.9.3"
       }
     },
     "node_modules/async-limiter": {
@@ -64,16 +64,17 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/ws": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "thrift": "^0.20.0"
   },
   "devDependencies": {
-    "typescript": "^4.5.4"
+    "typescript": "^5.9.3"
   },
   "license": "Apache-2.0",
   "files": [

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.10.0")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.4.0")
 addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "22.1.0")
-addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "4.0.1-PREVIEW.update-ts-config-target-to-es6.2026-05-15T1456.a0d2ee45")
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "4.0.1")
 addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.0")
 
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.10.0")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.4.0")
 addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "22.1.0")
-addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.6.0")
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "4.0.1-PREVIEW.update-ts-config-target-to-es6.2026-05-15T1456.a0d2ee45")
 addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.0")
 
 


### PR DESCRIPTION
Co-authored-by: Marjan K <15894063+marjisound@users.noreply.github.com>

## What does this change?

1.

Updates `sbt-scrooge-typescript` to fix the version selection of Typescript.

Currently npm publishing fails as the `ScroogeTypescriptGen` plugin from [scrooge-extras ](https://github.com/guardian/scrooge-extras) throws an error when running it's internal `tsc` command.

The generated [`tsconfig.json`](https://github.com/guardian/scrooge-extras/blob/d66019c15d58ed4def90b834baa69b19fb3b92ac/sbt-scrooge-typescript/src/main/scala/com/gu/thrift/ScroogeTypescriptGen.scala#L88-L108) uses a target of `ES5`, however it then runs the global version of `tsc` which (now) resolves to v6, rather than the expected version of v5.

The correct selection of TypeScript by `ScroogeTypescriptGen` was fixed (many years ago) here:
https://github.com/guardian/scrooge-extras/pull/25

However content-atom is still on an old version with this bug.

Updating the version of `sbt-scrooge-typescript` / `scrooge-extras` fixes this problem.

Full explanation here:
https://github.com/guardian/scrooge-extras/pull/59

2.

Add a tag via setting `scroogeTypescriptPublishTag` to the npm publish step for preview versions. This has become mandatory and without it npm publishing fails.

e.g.

https://github.com/guardian/content-atom/actions/runs/25926886336/job/76212295685#step:6:100

```
npm error You must specify a tag using --tag when publishing a prerelease version.
```

3.

Update TypeScript to v5.9.3

## How has this change been tested?

Tested here:
https://github.com/guardian/content-api-models/pull/304