### PR TITLE
Add codecs to media assets

### DIFF
--- a/thrift/src/main/thrift/atoms/media.thrift
+++ b/thrift/src/main/thrift/atoms/media.thrift
@@ -68,7 +68,8 @@ struct Asset {
   8: optional i64 duration // seconds
   /** video only: if a video has non-silent audio tracks **/
   9: optional bool hasAudio
-
+  /** e.g. "avc1.64001e". See https://developer.mozilla.org/en-US/docs/Web/API/WebCodecs_API/Codec_selection **/
+  10: optional set<string> codecs
 }
 
 struct PlutoData {


### PR DESCRIPTION
Mime type is not sufficient to fully specify the format of the video. For example, MP4 (video/mp4) and HLS/M3U8 (application/vnd.apple.mpegurl) are both containers that can include H264, AV1, AAC, MP3, etc.

Not all consumers can render all codecs, so it would be helpful for the model to include which codecs each asset contains. On web, we can include this in the codecs parameter of the `type` field of the source so that the browser can select an appropriate source without having to fetch it first. On mobile apps we will need to do this selection ourselves.

This field will follow the spec of https://w3c.github.io/webcodecs/codec_registry.html (see also https://developer.mozilla.org/en-US/docs/Web/API/WebCodecs_API/Codec_selection).  For example, our current H264 codec is avc1.64001e, our current AAC codec is mp4a.40.2 and our current AV1 codec is av01.0.04M.08.



<!-- Your thrift defintions need to also include a scala namespace. It looks like a comment but it's important to have it or generated scala isn't packaged correctly. See the README for more details. -->

<!-- Please ensure you have made corresponding changes to the elasticsearch mappings in CAPI https://git.io/v7cQs ? -->
