### PR TITLE
Disable compatibility checking to resolve broken release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ lazy val root = Project(id = "root", base = file("."))
   .aggregate(thrift, scalaClasses)
   .settings(
     publish / skip := true,
-    releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value,
+    //releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value,
     releaseProcess := Seq[ReleaseStep](
       checkSnapshotDependencies,
       inquireVersions,


### PR DESCRIPTION
Releasing v12.0.0 failed due to a network timeout. Since v12.0.0 isn't in Maven, but Github thinks it exists, subsequent attempts to assess compatibility with v12.0.0 will always fail.

To resolve this situation we are temporarily disabling the compatibility check.

Once we have successfully released v12.0.1 we will re-enable compatibility checking.



<!-- Your thrift defintions need to also include a scala namespace. It looks like a comment but it's important to have it or generated scala isn't packaged correctly. See the README for more details. -->

<!-- Please ensure you have made corresponding changes to the elasticsearch mappings in CAPI https://git.io/v7cQs ? -->
