### PR TITLE
add circe encoders and decoders as published artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is the Thrift definition of the Content Atom model, and the published versi
 
 ## Adding a new atom type
 
-In order for the scala code generated from the thrift definitions to be packaged correctly a scala namespace needs to be included. For example for the chart atom this would be:
+In order for the Scala code generated from the thrift definitions to be packaged correctly a scala namespace needs to be included. For example for the chart atom this would be:
 `#@namespace scala com.gu.contentatom.thrift.atom.chart`
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -11,12 +11,12 @@ val thriftVersion = "0.20.0"    // remember to also update package.json if the t
 
 val artifactProductionSettings = Seq(
   organization := "com.gu",
-  scalaVersion := "2.13.12",
+  scalaVersion := "2.13.14", // bug prevents building json package at >= 2.13.15
   // downgrade scrooge reserved word clashes to warnings
   Compile / scroogeDisableStrict := true,
   // Scrooge 21.3.0 dropped support for scala < 2.12, so we can only build for Scala 2.12+
   // https://twitter.github.io/scrooge/changelog.html#id11
-	crossScalaVersions := Seq("2.12.18", scalaVersion.value),
+  crossScalaVersions := Seq("2.12.21", scalaVersion.value),
   licenses := Seq(License.Apache2)
   /*
   Test / testOptions +=
@@ -25,7 +25,7 @@ val artifactProductionSettings = Seq(
 )
 
 lazy val root = Project(id = "root", base = file("."))
-  .aggregate(thrift, scalaClasses)
+  .aggregate(thrift, scalaClasses, json)
   .settings(
     publish / skip := true,
     releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value,
@@ -51,7 +51,7 @@ lazy val thrift = Project(id = "content-atom-model-thrift", base = file("thrift"
     packageDoc / publishArtifact := false,
     packageSrc / publishArtifact := false,
     unmanagedResources / includeFilter := "*.thrift",
-    Compile / unmanagedResourceDirectories += { baseDirectory.value / "src/main/thrift" }
+    Compile / unmanagedResourceDirectories += { baseDirectory.value / "src/main/thrift" },
   )
 
 lazy val scalaClasses = Project(id = "content-atom-model", base = file("scala"))
@@ -60,8 +60,8 @@ lazy val scalaClasses = Project(id = "content-atom-model", base = file("scala"))
     description := "Scala library built from Content-atom thrift definition",
     Compile / scroogeThriftSourceFolder := baseDirectory.value / "../thrift/src/main/thrift",
     Compile / scroogeThriftOutputFolder := sourceManaged.value,
+    Compile / managedSourceDirectories += (Compile / scroogeThriftOutputFolder).value,
     Compile / scroogeThriftDependencies ++= Seq("content-entity-thrift"),
-    resolvers += Resolver.sonatypeRepo("public"),
     libraryDependencies ++= Seq(
       "com.gu" % "content-entity-thrift" % contentEntityVersion,
       "com.gu" %% "content-entity-model" % contentEntityVersion,
@@ -70,6 +70,19 @@ lazy val scalaClasses = Project(id = "content-atom-model", base = file("scala"))
     ),
     // Include the Thrift file in the published jar
     Compile / scroogePublishThrift := true
+  )
+
+lazy val json = Project(id = "content-atom-model-json", base = file("json"))
+  .settings(artifactProductionSettings)
+  .dependsOn(scalaClasses)
+  .disablePlugins(ScroogeSBT)
+  .settings(
+    description := "Circe json encoders and decoders for content atom model",
+    libraryDependencies ++= Seq(
+      "com.gu" %% "content-entity-model-json" % "4.1.0-PREVIEW.ancirce-encoder-decoders.2026-06-29T1027.e9a20d9a",
+      "com.gu" %% "fezziwig" % "2.0.1",
+      "io.circe" %% "circe-parser" % "0.14.15",
+    )
   )
 
 lazy val npmPreviewReleaseTagMaybe = if (sys.env.get("RELEASE_TYPE").contains("PREVIEW_FEATURE_BRANCH")) {

--- a/json/src/main/scala/com/gu/contentatom/json/CirceDecoders.scala
+++ b/json/src/main/scala/com/gu/contentatom/json/CirceDecoders.scala
@@ -1,0 +1,127 @@
+package com.gu.contentatom.json
+
+import com.gu.contentatom.thrift._
+import com.gu.contentatom.thrift.atom.audio._
+import com.gu.contentatom.thrift.atom.chart._
+import com.gu.contentatom.thrift.atom.commonsdivision._
+import com.gu.contentatom.thrift.atom.cta._
+import com.gu.contentatom.thrift.atom.emailsignup._
+import com.gu.contentatom.thrift.atom.explainer._
+import com.gu.contentatom.thrift.atom.interactive._
+import com.gu.contentatom.thrift.atom.guide._
+import com.gu.contentatom.thrift.atom.media.{Asset => MediaAsset, _}
+import com.gu.contentatom.thrift.atom.profile._
+import com.gu.contentatom.thrift.atom.qanda._
+import com.gu.contentatom.thrift.atom.quiz.{Asset => QuizAsset, _}
+import com.gu.contentatom.thrift.atom.review._
+import com.gu.contentatom.thrift.atom.timeline._
+import com.gu.contententity.json.CirceDecoders._
+import com.gu.fezziwig.CirceScroogeMacros._
+import com.gu.fezziwig.CirceScroogeWhiteboxMacros._
+import io.circe.Decoder
+import io.circe.generic.semiauto._
+
+object CirceDecoders {
+  // atoms/audio.thrift
+  implicit lazy val offPlatformDecoder: Decoder[OffPlatform] = deriveDecoder
+  implicit lazy val audioAtomDecoder: Decoder[AudioAtom] = deriveDecoder
+
+  // atoms/chart.thrift
+  implicit lazy val chartTypeDecoder: Decoder[ChartType] = deriveDecoder
+  implicit lazy val rangeDecoder: Decoder[Range] = deriveDecoder
+  implicit lazy val displaySettingsDecoder: Decoder[DisplaySettings] = deriveDecoder
+  implicit lazy val furnitureDecoder: Decoder[Furniture] = deriveDecoder
+  implicit lazy val rowTypeDecoder: Decoder[RowType] = deriveDecoder
+  implicit lazy val tabularDataDecoder: Decoder[TabularData] = deriveDecoder
+  implicit lazy val seriesColourDecoder: Decoder[SeriesColour] = deriveDecoder
+  implicit lazy val axisDecoder: Decoder[Axis] = deriveDecoder
+  implicit lazy val chartAtomDecoder: Decoder[ChartAtom] = deriveDecoder
+
+  // atoms/commonsdivision.thrift
+  implicit lazy val mPDecoder: Decoder[Mp] = deriveDecoder
+  implicit lazy val votesDecoder: Decoder[Votes] = deriveDecoder
+  implicit lazy val commonsDivisionDecoder: Decoder[CommonsDivision] = deriveDecoder
+
+  // atoms/cta.thrift
+  implicit lazy val cTAAtomDecoder: Decoder[CTAAtom] = deriveDecoder
+
+  // atoms/emailsignup.thrift
+  implicit lazy val emailSignUpAtomDecoder: Decoder[EmailSignUpAtom] = deriveDecoder
+
+  // atoms/explainer.thrift
+  implicit lazy val displayTypeDecoder: Decoder[DisplayType] = deriveDecoder
+  implicit lazy val explainerAtomDecoder: Decoder[ExplainerAtom] = deriveDecoder
+
+  // atoms/guide.thrift
+  implicit lazy val guideItemDecoder: Decoder[GuideItem] = deriveDecoder
+  implicit lazy val guideAtomDecoder: Decoder[GuideAtom] = deriveDecoder
+
+  // atoms/interactive.thrift
+  implicit lazy val interactiveAtomDecoder: Decoder[InteractiveAtom] = deriveDecoder
+
+  // atoms/media.thrift
+  implicit lazy val platformDecoder: Decoder[Platform] = deriveDecoder
+  implicit lazy val assetTypeDecoder: Decoder[AssetType] = deriveDecoder
+  implicit lazy val categoryDecoder: Decoder[Category] = deriveDecoder
+  implicit lazy val privacyStatusDecoder: Decoder[PrivacyStatus] = deriveDecoder
+  implicit lazy val videoPlayerFormatDecoder: Decoder[VideoPlayerFormat] = deriveDecoder
+  implicit lazy val mediaAssetDecoder: Decoder[MediaAsset] = deriveDecoder
+  implicit lazy val plutoDataDecoder: Decoder[PlutoData] = deriveDecoder
+  implicit lazy val iconikDataDecoder: Decoder[IconikData] = deriveDecoder
+  implicit lazy val youtubeDataDecoder: Decoder[YoutubeData] = deriveDecoder
+  implicit lazy val selfHostDataDecoder: Decoder[SelfHostData] = deriveDecoder
+  implicit lazy val metadataDecoder: Decoder[Metadata] = deriveDecoder
+  implicit lazy val mediaAtomDecoder: Decoder[MediaAtom] = deriveDecoder
+
+  // atoms/profile.thrift
+  implicit lazy val profileItemDecoder: Decoder[ProfileItem] = deriveDecoder
+  implicit lazy val profileAtomDecoder: Decoder[ProfileAtom] = deriveDecoder
+
+  // atoms/qanda.thrift
+  implicit lazy val qAndAItemDecoder: Decoder[QAndAItem] = deriveDecoder
+  implicit lazy val qAndAAtomDecoder: Decoder[QAndAAtom] = deriveDecoder
+
+  // atoms/quiz.thrift
+  implicit lazy val resultGroupDecoder: Decoder[ResultGroup] = deriveDecoder
+  implicit lazy val quizAssetDecoder: Decoder[QuizAsset] = deriveDecoder
+  implicit lazy val answerDecoder: Decoder[Answer] = deriveDecoder
+  implicit lazy val resultBucketDecoder: Decoder[ResultBucket] = deriveDecoder
+  implicit lazy val resultBucketsDecoder: Decoder[ResultBuckets] = deriveDecoder
+  implicit lazy val questionDecoder: Decoder[Question] = deriveDecoder
+  implicit lazy val resultGroupsDecoder: Decoder[ResultGroups] = deriveDecoder
+  implicit lazy val quizContentDecoder: Decoder[QuizContent] = deriveDecoder
+  implicit lazy val quizAtomDecoder: Decoder[QuizAtom] = deriveDecoder
+
+  // atoms/review.thrift
+  implicit lazy val reviewTypeDecoder: Decoder[ReviewType] = deriveDecoder
+  implicit lazy val ratingDecoder: Decoder[Rating] = deriveDecoder
+  implicit lazy val reviewAtomDecoder: Decoder[ReviewAtom] = deriveDecoder
+
+  // atoms/shared.thrift
+  implicit lazy val userDecoder: Decoder[User] = deriveDecoder
+  implicit lazy val changeRecordDecoder: Decoder[ChangeRecord] = deriveDecoder
+  implicit lazy val sectionDecoder: Decoder[Section] = deriveDecoder
+  implicit lazy val tagDecoder: Decoder[Tag] = deriveDecoder
+  implicit lazy val newspaperDecoder: Decoder[Newspaper] = deriveDecoder
+  implicit lazy val tagUsageDecoder: Decoder[TagUsage] = deriveDecoder
+  implicit lazy val referenceDecoder: Decoder[Reference] = deriveDecoder
+  implicit lazy val taxonomyDecoder: Decoder[Taxonomy] = deriveDecoder
+  implicit lazy val imageAssetDimensionsDecoder: Decoder[ImageAssetDimensions] = deriveDecoder
+  implicit lazy val imageAssetDecoder: Decoder[ImageAsset] = deriveDecoder
+  implicit lazy val imageDecoder: Decoder[Image] = deriveDecoder
+  implicit lazy val emailProviderDecoder: Decoder[EmailProvider] = deriveDecoder
+  implicit lazy val notificationProvidersDecoder: Decoder[NotificationProviders] = deriveDecoder
+
+  // atoms/timeline.thrift
+  implicit lazy val timelineItemDecoder: Decoder[TimelineItem] = deriveDecoder
+  implicit lazy val timelineAtomDecoder: Decoder[TimelineAtom] = deriveDecoder
+
+  // contentatom.thrift
+  implicit lazy val atomTypeDecoder: Decoder[AtomType] = deriveDecoder
+  implicit lazy val atomDataDecoder: Decoder[AtomData] = deriveDecoder
+  implicit lazy val contentChangeDetailsDecoder: Decoder[ContentChangeDetails] = deriveDecoder
+  implicit lazy val flagsDecoder: Decoder[Flags] = deriveDecoder
+  implicit lazy val atomDecoder: Decoder[Atom] = deriveDecoder
+  implicit lazy val eventTypeDecoder: Decoder[EventType] = deriveDecoder
+  implicit lazy val contentAtomEventDecoder: Decoder[ContentAtomEvent] = deriveDecoder
+}

--- a/json/src/main/scala/com/gu/contentatom/json/CirceEncoders.scala
+++ b/json/src/main/scala/com/gu/contentatom/json/CirceEncoders.scala
@@ -1,0 +1,127 @@
+package com.gu.contentatom.json
+
+import com.gu.contentatom.thrift._
+import com.gu.contentatom.thrift.atom.audio._
+import com.gu.contentatom.thrift.atom.chart._
+import com.gu.contentatom.thrift.atom.commonsdivision._
+import com.gu.contentatom.thrift.atom.cta._
+import com.gu.contentatom.thrift.atom.emailsignup._
+import com.gu.contentatom.thrift.atom.explainer._
+import com.gu.contentatom.thrift.atom.guide._
+import com.gu.contentatom.thrift.atom.interactive._
+import com.gu.contentatom.thrift.atom.media.{Asset => MediaAsset, _}
+import com.gu.contentatom.thrift.atom.profile._
+import com.gu.contentatom.thrift.atom.qanda._
+import com.gu.contentatom.thrift.atom.quiz.{Asset => QuizAsset, _}
+import com.gu.contentatom.thrift.atom.review._
+import com.gu.contentatom.thrift.atom.timeline._
+import com.gu.contententity.json.CirceEncoders._
+import com.gu.fezziwig.CirceScroogeMacros._
+import com.gu.fezziwig.CirceScroogeWhiteboxMacros._
+import io.circe.Encoder
+import io.circe.generic.semiauto._
+
+object CirceEncoders {
+  // atoms/audio.thrift
+  implicit lazy val offPlatformEncoder: Encoder[OffPlatform] = deriveEncoder
+  implicit lazy val audioAtomEncoder: Encoder[AudioAtom] = deriveEncoder
+
+  // atoms/chart.thrift
+  implicit lazy val chartTypeEncoder: Encoder[ChartType] = deriveEncoder
+  implicit lazy val rangeEncoder: Encoder[Range] = deriveEncoder
+  implicit lazy val displaySettingsEncoder: Encoder[DisplaySettings] = deriveEncoder
+  implicit lazy val furnitureEncoder: Encoder[Furniture] = deriveEncoder
+  implicit lazy val rowTypeEncoder: Encoder[RowType] = deriveEncoder
+  implicit lazy val tabularDataEncoder: Encoder[TabularData] = deriveEncoder
+  implicit lazy val seriesColourEncoder: Encoder[SeriesColour] = deriveEncoder
+  implicit lazy val axisEncoder: Encoder[Axis] = deriveEncoder
+  implicit lazy val chartAtomEncoder: Encoder[ChartAtom] = deriveEncoder
+
+  // atoms/commonsdivision.thrift
+  implicit lazy val mPEncoder: Encoder[Mp] = deriveEncoder
+  implicit lazy val votesEncoder: Encoder[Votes] = deriveEncoder
+  implicit lazy val commonsDivisionEncoder: Encoder[CommonsDivision] = deriveEncoder
+
+  // atoms/cta.thrift
+  implicit lazy val cTAAtomEncoder: Encoder[CTAAtom] = deriveEncoder
+
+  // atoms/emailsignup.thrift
+  implicit lazy val emailSignUpAtomEncoder: Encoder[EmailSignUpAtom] = deriveEncoder
+
+  // atoms/explainer.thrift
+  implicit lazy val displayTypeEncoder: Encoder[DisplayType] = deriveEncoder
+  implicit lazy val explainerAtomEncoder: Encoder[ExplainerAtom] = deriveEncoder
+
+  // atoms/guide.thrift
+  implicit lazy val guideItemEncoder: Encoder[GuideItem] = deriveEncoder
+  implicit lazy val guideAtomEncoder: Encoder[GuideAtom] = deriveEncoder
+
+  // atoms/interactive.thrift
+  implicit lazy val interactiveAtomEncoder: Encoder[InteractiveAtom] = deriveEncoder
+
+  // atoms/media.thrift
+  implicit lazy val platformEncoder: Encoder[Platform] = deriveEncoder
+  implicit lazy val assetTypeEncoder: Encoder[AssetType] = deriveEncoder
+  implicit lazy val categoryEncoder: Encoder[Category] = deriveEncoder
+  implicit lazy val privacyStatusEncoder: Encoder[PrivacyStatus] = deriveEncoder
+  implicit lazy val videoPlayerFormatEncoder: Encoder[VideoPlayerFormat] = deriveEncoder
+  implicit lazy val mediaAssetEncoder: Encoder[MediaAsset] = deriveEncoder
+  implicit lazy val plutoDataEncoder: Encoder[PlutoData] = deriveEncoder
+  implicit lazy val iconikDataEncoder: Encoder[IconikData] = deriveEncoder
+  implicit lazy val youtubeDataEncoder: Encoder[YoutubeData] = deriveEncoder
+  implicit lazy val selfHostDataEncoder: Encoder[SelfHostData] = deriveEncoder
+  implicit lazy val metadataEncoder: Encoder[Metadata] = deriveEncoder
+  implicit lazy val mediaAtomEncoder: Encoder[MediaAtom] = deriveEncoder
+
+  // atoms/profile.thrift
+  implicit lazy val profileItemEncoder: Encoder[ProfileItem] = deriveEncoder
+  implicit lazy val profileAtomEncoder: Encoder[ProfileAtom] = deriveEncoder
+
+  // atoms/qanda.thrift
+  implicit lazy val qAndAItemEncoder: Encoder[QAndAItem] = deriveEncoder
+  implicit lazy val qAndAAtomEncoder: Encoder[QAndAAtom] = deriveEncoder
+
+  // atoms/quiz.thrift
+  implicit lazy val resultGroupEncoder: Encoder[ResultGroup] = deriveEncoder
+  implicit lazy val quizAssetEncoder: Encoder[QuizAsset] = deriveEncoder
+  implicit lazy val answerEncoder: Encoder[Answer] = deriveEncoder
+  implicit lazy val resultBucketEncoder: Encoder[ResultBucket] = deriveEncoder
+  implicit lazy val resultBucketsEncoder: Encoder[ResultBuckets] = deriveEncoder
+  implicit lazy val questionEncoder: Encoder[Question] = deriveEncoder
+  implicit lazy val resultGroupsEncoder: Encoder[ResultGroups] = deriveEncoder
+  implicit lazy val quizContentEncoder: Encoder[QuizContent] = deriveEncoder
+  implicit lazy val quizAtomEncoder: Encoder[QuizAtom] = deriveEncoder
+
+  // atoms/review.thrift
+  implicit lazy val reviewTypeEncoder: Encoder[ReviewType] = deriveEncoder
+  implicit lazy val ratingEncoder: Encoder[Rating] = deriveEncoder
+  implicit lazy val reviewAtomEncoder: Encoder[ReviewAtom] = deriveEncoder
+
+  // atoms/shared.thrift
+  implicit lazy val userEncoder: Encoder[User] = deriveEncoder
+  implicit lazy val changeRecordEncoder: Encoder[ChangeRecord] = deriveEncoder
+  implicit lazy val sectionEncoder: Encoder[Section] = deriveEncoder
+  implicit lazy val tagEncoder: Encoder[Tag] = deriveEncoder
+  implicit lazy val newspaperEncoder: Encoder[Newspaper] = deriveEncoder
+  implicit lazy val tagUsageEncoder: Encoder[TagUsage] = deriveEncoder
+  implicit lazy val referenceEncoder: Encoder[Reference] = deriveEncoder
+  implicit lazy val taxonomyEncoder: Encoder[Taxonomy] = deriveEncoder
+  implicit lazy val imageAssetDimensionsEncoder: Encoder[ImageAssetDimensions] = deriveEncoder
+  implicit lazy val imageAssetEncoder: Encoder[ImageAsset] = deriveEncoder
+  implicit lazy val imageEncoder: Encoder[Image] = deriveEncoder
+  implicit lazy val emailProviderEncoder: Encoder[EmailProvider] = deriveEncoder
+  implicit lazy val notificationProvidersEncoder: Encoder[NotificationProviders] = deriveEncoder
+
+  // atoms/timeline.thrift
+  implicit lazy val timelineItemEncoder: Encoder[TimelineItem] = deriveEncoder
+  implicit lazy val timelineAtomEncoder: Encoder[TimelineAtom] = deriveEncoder
+
+  // contentatom.thrift
+  implicit lazy val atomTypeEncoder: Encoder[AtomType] = deriveEncoder
+  implicit lazy val atomDataEncoder: Encoder[AtomData] = deriveEncoder
+  implicit lazy val contentChangeDetailsEncoder: Encoder[ContentChangeDetails] = deriveEncoder
+  implicit lazy val flagsEncoder: Encoder[Flags] = deriveEncoder
+  implicit lazy val atomEncoder: Encoder[Atom] = deriveEncoder
+  implicit lazy val eventTypeEncoder: Encoder[EventType] = deriveEncoder
+  implicit lazy val contentAtomEventEncoder: Encoder[ContentAtomEvent] = deriveEncoder
+}


### PR DESCRIPTION
Adds circe encoders and decoders as a published artifact, to avoid each consumer needing to write the list of encoders and decoders themselves.



<!-- Your thrift defintions need to also include a scala namespace. It looks like a comment but it's important to have it or generated scala isn't packaged correctly. See the README for more details. -->

<!-- Please ensure you have made corresponding changes to the elasticsearch mappings in CAPI https://git.io/v7cQs ? -->
