### PR TITLE
Update package-lock.json to be in sync with package.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,11 @@ jobs:
       - uses: sbt/setup-sbt@v1.1.0
       - name: Build and test
         run: sbt compile test
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          registry-url: https://registry.npmjs.org
+      - run: npm ci
       - name: Test Summary
         uses: test-summary/action@v2
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,16 +9,11 @@
       "version": "7.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "thrift": "^0.20.0"
+        "thrift": "0.24.0"
       },
       "devDependencies": {
         "typescript": "^5.9.3"
       }
-    },
-    "node_modules/async-limiter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
     "node_modules/browser-or-node": {
       "version": "1.3.0",
@@ -38,26 +33,17 @@
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="
     },
-    "node_modules/q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
-      "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
-      "engines": {
-        "node": ">=0.6.0",
-        "teleport": ">=0.2.0"
-      }
-    },
     "node_modules/thrift": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/thrift/-/thrift-0.20.0.tgz",
-      "integrity": "sha512-oSmJTaoIAGolpupVHFfsWcmdEKX81fcDI6ty0hhezzdgZvp0XyXgMe9+1YusI8Ahy0HK4n8jlNrkPjOPeHZjdQ==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/thrift/-/thrift-0.24.0.tgz",
+      "integrity": "sha512-v9eU1uxWXQ8+4hESZaXlwUBB89TDBM1Q0/EBs1uTg639Zi5qONoiX6mW68NGRoVeEbe4XhmIweB3rR8UMxP1jA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "browser-or-node": "^1.2.1",
         "isomorphic-ws": "^4.0.1",
         "node-int64": "^0.4.0",
-        "q": "^1.5.0",
-        "ws": "^5.2.3"
+        "uuid": "^14.0.0",
+        "ws": "^8.21.0"
       },
       "engines": {
         "node": ">= 10.18.0"
@@ -77,12 +63,38 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
     "node_modules/ws": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.4.tgz",
-      "integrity": "sha512-fFCejsuC8f9kOSu9FYaOw8CdO68O3h5v0lg4p74o8JqWpwTf9tniOD+nOB78aWoVSS6WptVUmDrp/KPsMVBWFQ==",
-      "dependencies": {
-        "async-limiter": "~1.0.0"
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     }
   }


### PR DESCRIPTION
When I updated thrift in this project’s package.json in https://github.com/guardian/content-atom/pull/222, I forgot to run `npm install` to update the package-lock.json. This PR first adds a check to the CI that will catch that if it happens again, and then updates the package-lock so the check passes.