### PR TITLE
Add build files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ target/
 .bsp/
 .metals
 .vscode
+/.bloop/
+/project/.bloop/
+/project/metals.sbt
+/project/project/


### PR DESCRIPTION
This PR updates the project’s .gitignore to ignore some build files that aren’t currently ignored. I think they’ve been gradually added in recent versions of sbt, or are coming from [metals](https://scalameta.org/metals/docs/).