### PR TITLE
spike multimedia slideshow atom

### DIFF
--- a/thrift/src/main/thrift/atoms/multimediaslideshow.thrift
+++ b/thrift/src/main/thrift/atoms/multimediaslideshow.thrift
@@ -1,0 +1,55 @@
+namespace * contentatom.multimediaslideshow
+namespace java com.gu.contentatom.thrift.atom.multimediaslideshow
+#@namespace scala com.gu.contentatom.thrift.atom.multimediaslideshow
+#@namespace typescript _at_guardian.content_atom_model.multimediaslideshow
+
+include "shared.thrift"
+
+/**
+* A reference to an existing media (video) atom.
+*
+* Used when a slide displays a video rather than a still image. The media
+* atom itself is stored separately and looked up via its atom id.
+*/
+struct MediaReference {
+  /** The id of the media atom to be displayed on this slide. */
+  1: required string mediaAtomId
+}
+
+/**
+* The content shown on an individual slide. A slide is either a still image
+* or a reference to a media (video) atom.
+*/
+union SlideContent {
+  1: shared.Image image
+  2: MediaReference mediaAtom
+}
+
+/**
+* A single slide within a multimedia slideshow.
+*/
+struct Slide {
+  /** The image or media atom displayed on this slide. */
+  1: required SlideContent content
+
+  /** Free text caption describing the slide. */
+  2: optional string caption
+
+  /** Short text label for the slide. */
+  3: optional string label
+
+  /** Picture or video credit text. */
+  4: optional string credit
+}
+
+/**
+* A multimedia slideshow made up of an ordered list of slides. Each slide can
+* be a still image or a media (video) atom.
+*/
+struct MultimediaSlideshowAtom {
+  /** The ordered list of slides that make up the slideshow. */
+  1: required list<Slide> slides
+
+  /** Optional title for the slideshow. */
+  2: optional string title
+}

--- a/thrift/src/main/thrift/contentatom.thrift
+++ b/thrift/src/main/thrift/contentatom.thrift
@@ -17,6 +17,7 @@ include "atoms/chart.thrift"
 include "atoms/audio.thrift"
 include "atoms/shared.thrift"
 include "atoms/emailsignup.thrift"
+include "atoms/multimediaslideshow.thrift"
 
 typedef string ContentAtomID
 
@@ -37,7 +38,8 @@ enum AtomType {
   COMMONSDIVISION = 13,
   CHART = 14,
   AUDIO = 15,
-  EMAILSIGNUP = 16
+  EMAILSIGNUP = 16,
+  MULTIMEDIASLIDESHOW = 17
 }
 
 union AtomData {
@@ -58,6 +60,7 @@ union AtomData {
   15: chart.ChartAtom chart
   16: audio.AudioAtom audio
   17: emailsignup.EmailSignUpAtom emailsignup
+  18: multimediaslideshow.MultimediaSlideshowAtom multimediaSlideshow
 }
 
 struct ContentChangeDetails {


### PR DESCRIPTION
Suggests the shape of a multimedia slideshow atom. 

The slide can be either an image (using the existing image type), or a media atom id, which may be sufficient information to store in the atom and enable platforms to look up the data. 

Part of https://github.com/guardian/eventkit-mission/issues/58

<!-- Your thrift defintions need to also include a scala namespace. It looks like a comment but it's important to have it or generated scala isn't packaged correctly. See the README for more details. -->

<!-- Please ensure you have made corresponding changes to the elasticsearch mappings in CAPI https://git.io/v7cQs ? -->
